### PR TITLE
test: Add schema validation and web utility tests

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
     "preview": "astro preview",
     "typecheck": "astro check",
     "lint": "echo 'web app lint not configured (Astro/Svelte needs separate plugins)'",
-    "test": "echo 'no tests yet'"
+    "test": "vitest run"
   },
   "dependencies": {
     "@civic-source/types": "workspace:*",
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.0",
-    "typescript": "^5.8.0"
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.2"
   }
 }

--- a/apps/web/src/__tests__/github.test.ts
+++ b/apps/web/src/__tests__/github.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizeContent,
+  sanitizeExcerpt,
+  formatTagName,
+  extractYear,
+  isRateLimited,
+} from '../lib/github';
+
+describe('sanitizeContent', () => {
+  it('strips basic HTML tags', () => {
+    expect(sanitizeContent('<b>bold</b>')).toBe('bold');
+  });
+
+  it('strips script blocks entirely', () => {
+    expect(sanitizeContent('before<script>alert("xss")</script>after')).toBe('beforeafter');
+  });
+
+  it('strips style blocks entirely', () => {
+    expect(sanitizeContent('text<style>.evil{}</style>more')).toBe('textmore');
+  });
+
+  it('strips HTML comments', () => {
+    expect(sanitizeContent('before<!-- hidden instruction -->after')).toBe('beforeafter');
+  });
+
+  it('decodes HTML entities and re-strips', () => {
+    expect(sanitizeContent('&lt;script&gt;alert(1)&lt;/script&gt;')).toBe('alert(1)');
+  });
+
+  it('handles nested/malformed tags', () => {
+    expect(sanitizeContent('<div><p>text</p></div>')).toBe('text');
+  });
+
+  it('returns plain text unchanged', () => {
+    expect(sanitizeContent('just plain text')).toBe('just plain text');
+  });
+});
+
+describe('sanitizeExcerpt', () => {
+  it('preserves mark tags from Pagefind', () => {
+    expect(sanitizeExcerpt('text <mark>match</mark> more')).toBe('text <mark>match</mark> more');
+  });
+
+  it('strips non-mark tags', () => {
+    expect(sanitizeExcerpt('<b>bold</b> <mark>match</mark>')).toBe('bold <mark>match</mark>');
+  });
+
+  it('strips script blocks', () => {
+    expect(sanitizeExcerpt('<mark>ok</mark><script>evil()</script>')).toBe('<mark>ok</mark>');
+  });
+
+  it('handles self-closing mark', () => {
+    expect(sanitizeExcerpt('text <mark>highlighted</mark> end')).toBe('text <mark>highlighted</mark> end');
+  });
+});
+
+describe('formatTagName', () => {
+  it('formats pl-113-100 to PL 113-100', () => {
+    expect(formatTagName('pl-113-100')).toBe('PL 113-100');
+  });
+});
+
+describe('extractYear', () => {
+  it('derives year from congress number', () => {
+    expect(extractYear('', 'pl-113-100')).toBe('2013');
+    expect(extractYear('', 'pl-119-73')).toBe('2025');
+  });
+
+  it('falls back to date string', () => {
+    expect(extractYear('2024-06-15T00:00:00Z')).toBe('2024');
+  });
+
+  it('returns empty for no date and no tag', () => {
+    expect(extractYear('')).toBe('');
+  });
+});
+
+describe('isRateLimited', () => {
+  it('detects 403 as rate limited', () => {
+    expect(isRateLimited({ status: 403 })).toBe(true);
+  });
+
+  it('detects 429 as rate limited', () => {
+    expect(isRateLimited({ status: 429 })).toBe(true);
+  });
+
+  it('returns false for 500', () => {
+    expect(isRateLimited({ status: 500 })).toBe(false);
+  });
+
+  it('returns false for non-objects', () => {
+    expect(isRateLimited('error')).toBe(false);
+    expect(isRateLimited(null)).toBe(false);
+  });
+});

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,12 +15,13 @@
     "build": "tsc --project tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
-    "test": "echo 'no tests yet'"
+    "test": "vitest run"
   },
   "dependencies": {
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "typescript": "^5.8.0"
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.2"
   }
 }

--- a/packages/types/src/__tests__/schemas.test.ts
+++ b/packages/types/src/__tests__/schemas.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ReleasePointSchema,
+  CaseAnnotationSchema,
+  PrecedentAnnotationSchema,
+  PrecedentImpactSchema,
+  ok,
+  err,
+} from '../index.js';
+
+describe('Result helpers', () => {
+  it('ok wraps a value', () => {
+    const result = ok(42);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toBe(42);
+  });
+
+  it('err wraps an error', () => {
+    const result = err(new Error('fail'));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toBe('fail');
+  });
+});
+
+describe('ReleasePointSchema', () => {
+  const valid = {
+    title: '18',
+    publicLaw: 'PL 119-73',
+    dateET: '2026-01-15T12:00:00Z',
+    uslmUrl: 'https://uscode.house.gov/download/releasepoints/us/pl/119/73/xml_usc18@119-73.zip',
+    sha256Hash: 'a'.repeat(64),
+  };
+
+  it('accepts a valid release point', () => {
+    expect(ReleasePointSchema.parse(valid)).toEqual(valid);
+  });
+
+  it('rejects empty title', () => {
+    expect(() => ReleasePointSchema.parse({ ...valid, title: '' })).toThrow();
+  });
+
+  it('rejects invalid URL', () => {
+    expect(() => ReleasePointSchema.parse({ ...valid, uslmUrl: 'not-a-url' })).toThrow();
+  });
+
+  it('rejects wrong-length sha256Hash', () => {
+    expect(() => ReleasePointSchema.parse({ ...valid, sha256Hash: 'abc' })).toThrow();
+  });
+
+  it('rejects invalid dateET format', () => {
+    expect(() => ReleasePointSchema.parse({ ...valid, dateET: 'March 15' })).toThrow();
+  });
+
+  it('rejects missing required fields', () => {
+    expect(() => ReleasePointSchema.parse({ title: '1' })).toThrow();
+  });
+});
+
+describe('PrecedentImpactSchema', () => {
+  it('accepts valid impacts', () => {
+    for (const impact of ['interpretation', 'unconstitutional', 'narrowed', 'historical']) {
+      expect(PrecedentImpactSchema.parse(impact)).toBe(impact);
+    }
+  });
+
+  it('rejects invalid impact', () => {
+    expect(() => PrecedentImpactSchema.parse('overturned')).toThrow();
+  });
+});
+
+describe('CaseAnnotationSchema', () => {
+  const valid = {
+    caseName: 'United States v. Smith',
+    citation: '500 U.S. 123 (2020)',
+    court: 'SCOTUS' as const,
+    date: '2020-06-15',
+    holdingSummary: 'Held that the statute applies to federal officers.',
+    sourceUrl: 'https://courtlistener.com/opinion/12345/',
+    impact: 'interpretation' as const,
+  };
+
+  it('accepts valid case annotation', () => {
+    expect(CaseAnnotationSchema.parse(valid)).toEqual(valid);
+  });
+
+  it('accepts optional statuteVersionRef', () => {
+    const withRef = { ...valid, statuteVersionRef: 'PL 117-81', statuteVersionNote: 'Current at time of decision' };
+    expect(CaseAnnotationSchema.parse(withRef)).toEqual(withRef);
+  });
+
+  it('rejects invalid court', () => {
+    expect(() => CaseAnnotationSchema.parse({ ...valid, court: 'State' })).toThrow();
+  });
+
+  it('rejects holdingSummary over 500 chars', () => {
+    expect(() => CaseAnnotationSchema.parse({ ...valid, holdingSummary: 'x'.repeat(501) })).toThrow();
+  });
+
+  it('accepts holdingSummary at exactly 500 chars', () => {
+    const atLimit = { ...valid, holdingSummary: 'x'.repeat(500) };
+    expect(CaseAnnotationSchema.parse(atLimit).holdingSummary).toHaveLength(500);
+  });
+});
+
+describe('PrecedentAnnotationSchema', () => {
+  it('accepts valid annotation with cases', () => {
+    const annotation = {
+      targetSection: '18 U.S.C. § 111',
+      lastSyncedET: '2026-03-29T18:00:00Z',
+      cases: [{
+        caseName: 'United States v. Doe',
+        citation: '600 U.S. 1 (2025)',
+        court: 'SCOTUS' as const,
+        date: '2025-01-01',
+        holdingSummary: 'Test holding',
+        sourceUrl: 'https://example.com/case',
+        impact: 'interpretation' as const,
+      }],
+    };
+    const result = PrecedentAnnotationSchema.parse(annotation);
+    expect(result.cases).toHaveLength(1);
+    expect(result.targetSection).toBe('18 U.S.C. § 111');
+  });
+
+  it('accepts empty cases array', () => {
+    const annotation = {
+      targetSection: '26 U.S.C. § 1',
+      lastSyncedET: '2026-01-01T00:00:00Z',
+      cases: [],
+    };
+    expect(PrecedentAnnotationSchema.parse(annotation).cases).toHaveLength(0);
+  });
+
+  it('rejects invalid lastSyncedET', () => {
+    expect(() => PrecedentAnnotationSchema.parse({
+      targetSection: 'test',
+      lastSyncedET: 'not-a-date',
+      cases: [],
+    })).toThrow();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
 
   packages/annotator:
     dependencies:
@@ -213,6 +216,9 @@ importers:
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
 
 packages:
 
@@ -4413,6 +4419,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/mocker@4.1.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+
   '@vitest/mocker@4.1.2(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.2
@@ -6473,6 +6487,33 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.2(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
## Summary
Adds test coverage to two previously untested packages:

**Types package** (18 tests):
- Zod schema validation for ReleasePointSchema, CaseAnnotationSchema, PrecedentAnnotationSchema
- Result helper (ok/err) round-trips
- Edge cases: empty fields, max lengths, invalid formats

**Web app** (19 tests):
- `sanitizeContent`: XSS vectors (script blocks, entities, comments)
- `sanitizeExcerpt`: Pagefind mark tag preservation
- `formatTagName`, `extractYear`, `isRateLimited` utility functions

Total new tests: **37** (was 0 in both packages)

## Issues
- Closes #65 (test coverage gaps)
- Unblocks #61 (major dep upgrade research — needs test safety net)

## Test plan
- [x] `pnpm test` — all 13 tasks pass (37 new tests + existing)
- [x] Types: 18 tests covering all schemas
- [x] Web: 19 tests covering sanitization + utilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)