### PR TITLE
feat: Auto-generated article table of contents for statutes

### DIFF
--- a/apps/web/src/components/ArticleToc.svelte
+++ b/apps/web/src/components/ArticleToc.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+  /**
+   * Auto-generated table of contents for statute content.
+   * Scans the target element for h2/h3 headings and renders a
+   * sticky sidebar TOC with active section highlighting.
+   * Only renders when 3+ headings are found.
+   */
+
+  interface TocEntry {
+    id: string;
+    text: string;
+    level: number;
+  }
+
+  interface Props {
+    /** CSS selector for the content element to scan for headings */
+    contentSelector?: string;
+  }
+
+  let { contentSelector = '.prose' }: Props = $props();
+
+  let entries = $state<TocEntry[]>([]);
+  let activeId = $state('');
+
+  $effect(() => {
+    const content = document.querySelector(contentSelector);
+    if (!content) return;
+
+    // Scan for headings
+    const headings = content.querySelectorAll('h2, h3');
+    const found: TocEntry[] = [];
+    let counter = 0;
+
+    for (const el of headings) {
+      const heading = el as HTMLElement;
+      // Ensure heading has an id for linking
+      if (!heading.id) {
+        heading.id = `toc-${counter++}`;
+      }
+      found.push({
+        id: heading.id,
+        text: heading.textContent?.trim() ?? '',
+        level: heading.tagName === 'H2' ? 2 : 3,
+      });
+    }
+
+    entries = found;
+
+    if (found.length < 3) return; // Don't observe if too few headings
+
+    // IntersectionObserver for active section highlighting
+    const observer = new IntersectionObserver(
+      (intersections) => {
+        for (const entry of intersections) {
+          if (entry.isIntersecting) {
+            activeId = entry.target.id;
+          }
+        }
+      },
+      { rootMargin: '-80px 0px -60% 0px', threshold: 0 }
+    );
+
+    for (const heading of headings) {
+      observer.observe(heading);
+    }
+
+    return () => observer.disconnect();
+  });
+</script>
+
+{#if entries.length >= 3}
+  <nav class="sticky top-6 font-sans" aria-label="On this page">
+    <h2 class="mb-2 text-[11px] font-semibold uppercase tracking-wider text-slate dark:text-gray-500">
+      On this page
+    </h2>
+    <ul class="max-h-[calc(100vh-10rem)] space-y-0.5 overflow-y-auto text-xs">
+      {#each entries as entry (entry.id)}
+        <li>
+          <a
+            href="#{entry.id}"
+            class="block rounded px-2 py-0.5 transition-colors {entry.level === 3 ? 'pl-4' : ''}
+              {activeId === entry.id
+                ? 'bg-teal/10 font-medium text-teal dark:text-teal-bright'
+                : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300'
+              }"
+          >
+            {entry.text}
+          </a>
+        </li>
+      {/each}
+    </ul>
+  </nav>
+{/if}

--- a/apps/web/src/pages/statute/[...slug].astro
+++ b/apps/web/src/pages/statute/[...slug].astro
@@ -4,6 +4,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import DiffViewer from '../../components/DiffViewer.svelte';
 import PrecedentDrawer from '../../components/PrecedentDrawer.svelte';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
+import ArticleToc from '../../components/ArticleToc.svelte';
 
 export async function getStaticPaths() {
   const entries = await getCollection('statutes');
@@ -178,10 +179,14 @@ const isRenumbered = entry.data.title.includes('Renumbered');
       <Content />
     </div>
 
-    <!-- Chapter TOC sidebar -->
-    {chapterSiblings.length > 1 && (
-      <aside class="hidden w-56 shrink-0 lg:block">
-        <nav class="sticky top-6 font-sans" aria-label="Chapter sections">
+    <!-- Right sidebar: Article TOC + Chapter sections -->
+    <aside class="hidden w-56 shrink-0 lg:block">
+      <!-- Article TOC (only renders for pages with 3+ headings) -->
+      <ArticleToc client:idle contentSelector=".prose" />
+
+      <!-- Chapter TOC -->
+      {chapterSiblings.length > 1 && (
+        <nav class="sticky top-6 mt-4 font-sans" aria-label="Chapter sections">
           <h2 class="mb-3 text-xs font-semibold uppercase tracking-wider text-slate dark:text-gray-500">
             Chapter {chapter} Sections
           </h2>
@@ -207,8 +212,8 @@ const isRenumbered = entry.data.title.includes('Renumbered');
             })}
           </ul>
         </nav>
-      </aside>
-    )}
+      )}
+    </aside>
   </div>
 
   <!-- Prev / Next section navigation -->


### PR DESCRIPTION
## Summary
New `ArticleToc.svelte` component that auto-generates a sticky table of contents for statute pages with complex content.

**How it works:**
- Scans the `.prose` container for h2/h3 headings on mount
- Assigns IDs to headings that don't have them
- Renders a compact sidebar TOC with smooth scroll links
- Highlights the active section using IntersectionObserver
- Only renders when 3+ headings are found (most single-section statutes are short)
- h3 entries are indented for visual hierarchy

**Integration:** Placed in the right sidebar above the chapter sections list. Uses `client:idle` for non-blocking hydration.

## Issues
- Closes #71

## Test plan
- [x] `pnpm test` — all 266 tests pass
- [x] `svelte-check` — 0 errors
- [ ] Visual: verify TOC appears on complex statutes (e.g., Title 26 § 1400Z-1)
- [ ] Visual: verify TOC hidden on short statutes (e.g., Title 42 § 301)
- [ ] Verify IntersectionObserver active highlighting works on scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)