### PR TITLE
fix(a11y): Status icons and text labels for colorblind accessibility

### DIFF
--- a/apps/web/src/pages/browse/[title]/[chapter].astro
+++ b/apps/web/src/pages/browse/[title]/[chapter].astro
@@ -64,21 +64,36 @@ const base = import.meta.env.BASE_URL;
 
   <div class="not-prose mt-6">
     <ul class="divide-y divide-gray-200 rounded-lg border border-gray-200 dark:divide-gray-800 dark:border-gray-800">
-      {sortedSections.map((entry) => (
-        <li>
-          <a
-            href={`${base}statute/${entry.id}/`}
-            class="flex items-baseline gap-3 px-4 py-3 font-sans text-sm transition-colors hover:bg-gray-50 dark:hover:bg-gray-900"
-          >
-            <span class="w-16 shrink-0 text-right font-mono text-xs text-slate dark:text-gray-500">
-              &sect; {entry.data.usc_section}
-            </span>
-            <span class="text-navy dark:text-gray-200">
-              {entry.data.title}
-            </span>
-          </a>
-        </li>
-      ))}
+      {sortedSections.map((entry) => {
+        const sTitle = entry.data.title;
+        const isRepealed = sTitle.includes('Repealed');
+        const isReserved = sTitle.includes('Reserved');
+        const isOmitted = sTitle.includes('Omitted');
+        const isTransferred = sTitle.includes('Transferred') && !sTitle.includes('Transferred or reemployed');
+        const isInactive = isRepealed || isReserved || isOmitted || isTransferred;
+        return (
+          <li>
+            <a
+              href={`${base}statute/${entry.id}/`}
+              class:list={[
+                'flex items-baseline gap-3 px-4 py-3 font-sans text-sm transition-colors hover:bg-gray-50 dark:hover:bg-gray-900',
+                isInactive && 'opacity-60',
+              ]}
+            >
+              <span class="w-16 shrink-0 text-right font-mono text-xs text-slate dark:text-gray-500">
+                &sect; {entry.data.usc_section}
+              </span>
+              <span class:list={['text-navy dark:text-gray-200', isInactive && 'italic']}>
+                {sTitle}
+              </span>
+              {isRepealed && <span class="ml-auto rounded bg-amber/15 px-1.5 py-0.5 text-[10px] font-medium text-amber">Repealed</span>}
+              {isReserved && <span class="ml-auto rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-800">Reserved</span>}
+              {isOmitted && <span class="ml-auto rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-800">Omitted</span>}
+              {isTransferred && <span class="ml-auto rounded bg-teal/10 px-1.5 py-0.5 text-[10px] font-medium text-teal">Transferred</span>}
+            </a>
+          </li>
+        );
+      })}
     </ul>
   </div>
 </BaseLayout>

--- a/apps/web/src/pages/statute/[...slug].astro
+++ b/apps/web/src/pages/statute/[...slug].astro
@@ -113,34 +113,60 @@ const isRenumbered = entry.data.title.includes('Renumbered');
     </div>
   </div>
 
-  <!-- Repealed / Reserved notices -->
+  <!-- Repealed / Reserved / Omitted / Transferred / Renumbered notices -->
+  <!-- Each notice uses role="status", an icon, and explicit text label alongside color for colorblind accessibility -->
   {isRepealed && (
-    <div class="not-prose my-4 rounded-lg border border-amber/30 bg-amber/5 p-4 text-sm font-sans">
-      <p class="font-medium text-amber">This section has been repealed.</p>
-      <p class="mt-1 text-slate">The repeal information is shown in the heading above.</p>
+    <div class="not-prose my-4 rounded-lg border border-amber/30 bg-amber/5 p-4 text-sm font-sans" role="status">
+      <p class="flex items-center gap-2 font-medium text-amber">
+        <svg class="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+        </svg>
+        <span>Repealed</span> — This section has been repealed.
+      </p>
+      <p class="mt-1 pl-6 text-slate">The repeal information is shown in the heading above.</p>
     </div>
   )}
   {isReserved && (
-    <div class="not-prose my-4 rounded-lg border border-gray-300 bg-gray-50 p-4 text-sm font-sans dark:border-gray-700 dark:bg-gray-900">
-      <p class="font-medium">This section is reserved for future legislation.</p>
+    <div class="not-prose my-4 rounded-lg border border-gray-300 bg-gray-50 p-4 text-sm font-sans dark:border-gray-700 dark:bg-gray-900" role="status">
+      <p class="flex items-center gap-2 font-medium">
+        <svg class="h-4 w-4 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <span>Reserved</span> — This section is reserved for future legislation.
+      </p>
     </div>
   )}
   {isOmitted && (
-    <div class="not-prose my-4 rounded-lg border border-gray-300 bg-gray-50 p-4 text-sm font-sans dark:border-gray-700 dark:bg-gray-900">
-      <p class="font-medium text-gray-600 dark:text-gray-400">This section was omitted from the Code.</p>
-      <p class="mt-1 text-gray-500 dark:text-gray-500">Omitted sections were formerly part of the U.S. Code but are no longer included, typically because the underlying law expired, was superseded, or was executed (completed its purpose).</p>
+    <div class="not-prose my-4 rounded-lg border border-gray-300 bg-gray-50 p-4 text-sm font-sans dark:border-gray-700 dark:bg-gray-900" role="status">
+      <p class="flex items-center gap-2 font-medium text-gray-600 dark:text-gray-400">
+        <svg class="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+        <span>Omitted</span> — This section was omitted from the Code.
+      </p>
+      <p class="mt-1 pl-6 text-gray-500 dark:text-gray-500">Omitted sections were formerly part of the U.S. Code but are no longer included, typically because the underlying law expired, was superseded, or was executed (completed its purpose).</p>
     </div>
   )}
   {isTransferred && (
-    <div class="not-prose my-4 rounded-lg border border-teal/30 bg-teal/5 p-4 text-sm font-sans">
-      <p class="font-medium text-teal">This section has been transferred.</p>
-      <p class="mt-1 text-gray-600 dark:text-gray-400">The content of this section has been moved to a different location in the U.S. Code. Check the heading above for the transfer reference.</p>
+    <div class="not-prose my-4 rounded-lg border border-teal/30 bg-teal/5 p-4 text-sm font-sans" role="status">
+      <p class="flex items-center gap-2 font-medium text-teal">
+        <svg class="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+        </svg>
+        <span>Transferred</span> — This section has been transferred.
+      </p>
+      <p class="mt-1 pl-6 text-gray-600 dark:text-gray-400">The content of this section has been moved to a different location in the U.S. Code. Check the heading above for the transfer reference.</p>
     </div>
   )}
   {isRenumbered && (
-    <div class="not-prose my-4 rounded-lg border border-teal/30 bg-teal/5 p-4 text-sm font-sans">
-      <p class="font-medium text-teal">This section has been renumbered.</p>
-      <p class="mt-1 text-gray-600 dark:text-gray-400">This section's number was changed. Check the heading above for the new section number.</p>
+    <div class="not-prose my-4 rounded-lg border border-teal/30 bg-teal/5 p-4 text-sm font-sans" role="status">
+      <p class="flex items-center gap-2 font-medium text-teal">
+        <svg class="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
+        </svg>
+        <span>Renumbered</span> — This section has been renumbered.
+      </p>
+      <p class="mt-1 pl-6 text-gray-600 dark:text-gray-400">This section's number was changed. Check the heading above for the new section number.</p>
     </div>
   )}
 


### PR DESCRIPTION
## Summary
Addresses the remaining accessibility work from #70 — adding non-color status indicators.

### Statute page notices
- SVG icons alongside colored text: circle-slash (Repealed), clock (Reserved), trash (Omitted), arrow-right (Transferred), arrows (Renumbered)
- Explicit text labels before descriptions
- `role="status"` for screen readers
- Indented descriptions under icon/label alignment

### Chapter browse listings
- Inline status badges with text labels (Repealed, Reserved, Omitted, Transferred)
- Inactive sections dimmed with `opacity-60` and italic title
- Each badge uses color + text for dual-channel accessibility

## Issues
- Closes #70

## Test plan
- [x] `pnpm test` — all tests pass
- [x] `svelte-check` — 0 errors
- [ ] Visual: verify icons render alongside text on statute pages
- [ ] Visual: verify browse listings show status badges
- [ ] Accessibility: verify screen reader announces status via role="status"

🤖 Generated with [Claude Code](https://claude.com/claude-code)