### PR TITLE
fix(ci): Fix deploy cache key — use submodule SHA instead of refs/tags

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -46,11 +46,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Get submodule commit for cache key
+        id: submodule-ref
+        run: echo "sha=$(git -C apps/web/content-data rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Restore diff cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: apps/web/public/diffs/
-          key: diffs-${{ hashFiles('apps/web/content-data/.git/refs/tags/*') }}
+          key: diffs-${{ steps.submodule-ref.outputs.sha }}
           restore-keys: |
             diffs-
 


### PR DESCRIPTION
## Problem
Deploy workflow fails at the "Restore diff cache" step:
```
hashFiles('apps/web/content-data/.git/refs/tags/*') failed
```

**Root cause**: Submodule checkouts store tags in `packed-refs`, not individual files under `refs/tags/`. The `hashFiles()` glob finds nothing and errors.

## Fix
Replace `hashFiles()` with a step that gets the submodule HEAD SHA via `git rev-parse`. This changes whenever the submodule ref updates — exactly when cache invalidation is needed.

## Impact
Both recent deploy runs (23722343469, 23722141722) failed with this error. This fix unblocks deployment of all UX improvements from PRs #62-#75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)