### PR TITLE
fix(ci): Fetch PR base SHA before commitlint to fix squash merge failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
 
       - run: pnpm test
 
+      - name: Fetch PR base for commitlint
+        if: github.event_name == 'pull_request'
+        run: git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}
+
       - name: Validate commit messages
         if: github.event_name == 'pull_request'
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Problem
CI fails on the "Validate commit messages" step with:
```
Error: fatal: Invalid revision range <base_sha>..<head_sha>
```

This happens because squash merges discard intermediate commits, so the PR base SHA no longer exists in the shallow clone (depth=1).

## Fix
Add a `git fetch --depth=1 origin <base_sha>` step before commitlint runs. This fetches just the base commit needed for the revision range, without fetching full repo history (which would be slow due to the large us-code submodule).

## Affected runs
CI runs 23722511237, 23722139420, 23721435372 all failed with this error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)