### PR TITLE
fix: Add Renumbered badges to browse + cap Change History at 10

### DIFF
--- a/apps/web/src/components/DiffViewer.svelte
+++ b/apps/web/src/components/DiffViewer.svelte
@@ -54,6 +54,8 @@
   let manifest = $state<DiffManifest | null>(null);
   let expandedCongress = $state<Set<number>>(new Set());
   let onlyShowChanges = $state(true);
+  let showAllHistory = $state(false);
+  const HISTORY_PREVIEW_COUNT = 10;
 
   /** Parse congress number from a pl-* tag name */
   function parseCongress(tagName: string): number {
@@ -495,14 +497,21 @@
       {:else if !commits.some(c => isLegislativeChange(c.message))}
         <p class="mb-3 rounded bg-amber/10 p-2 text-xs text-amber dark:bg-amber/5">No legislative changes tracked yet. Future updates will appear here as diffs.</p>
       {/if}
+      {@const visibleCommits = showAllHistory ? commits : commits.slice(0, HISTORY_PREVIEW_COUNT)}
       <ul class="max-h-48 space-y-1 overflow-y-auto">
-        {#each commits as commit (commit.sha)}
+        {#each visibleCommits as commit (commit.sha)}
           <li class="rounded px-2 py-1 text-xs text-gray-700 dark:text-gray-300">
             <span>{formatCommitMessage(commit.message)}</span>
             <span class="ml-2 text-gray-400">{commitDisplayDate(commit.message, commit.date)}</span>
           </li>
         {/each}
       </ul>
+      {#if commits.length > HISTORY_PREVIEW_COUNT}
+        <button
+          class="mt-1 text-xs text-teal hover:underline dark:text-teal-bright"
+          onclick={() => showAllHistory = !showAllHistory}
+        >{showAllHistory ? `Show recent ${HISTORY_PREVIEW_COUNT}` : `Show all ${commits.length} changes`}</button>
+      {/if}
     {/if}
   {/if}
 </div>

--- a/apps/web/src/pages/browse/[title]/[chapter].astro
+++ b/apps/web/src/pages/browse/[title]/[chapter].astro
@@ -70,7 +70,8 @@ const base = import.meta.env.BASE_URL;
         const isReserved = sTitle.includes('Reserved');
         const isOmitted = sTitle.includes('Omitted');
         const isTransferred = sTitle.includes('Transferred') && !sTitle.includes('Transferred or reemployed');
-        const isInactive = isRepealed || isReserved || isOmitted || isTransferred;
+        const isRenumbered = sTitle.includes('Renumbered');
+        const isInactive = isRepealed || isReserved || isOmitted || isTransferred || isRenumbered;
         return (
           <li>
             <a
@@ -90,6 +91,7 @@ const base = import.meta.env.BASE_URL;
               {isReserved && <span class="ml-auto rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-800">Reserved</span>}
               {isOmitted && <span class="ml-auto rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-800">Omitted</span>}
               {isTransferred && <span class="ml-auto rounded bg-teal/10 px-1.5 py-0.5 text-[10px] font-medium text-teal">Transferred</span>}
+              {isRenumbered && <span class="ml-auto rounded bg-teal/10 px-1.5 py-0.5 text-[10px] font-medium text-teal">Renumbered</span>}
             </a>
           </li>
         );


### PR DESCRIPTION
## Summary
Found during live site review with browser automation:

### Browse listings fix
- **Bug**: "Renumbered" sections (e.g., §1952A) had no status badge or dimming — only the statute detail page detected "Renumbered", not the chapter browse listing
- **Fix**: Add `isRenumbered` detection + badge + opacity-60 + italic treatment

### Change History UX
- **Problem**: Sections with many historical versions show 48+ entries in a flat list
- **Fix**: Show only 10 most recent by default, with "Show all N changes" toggle

## Issues
- Closes #88

## Test plan
- [x] `svelte-check` — 0 errors
- [x] `pnpm test` — all pass
- [ ] Visual: verify Renumbered badge on Title 18 Chapter 95 (§1952A, §1952B)
- [ ] Visual: verify Change History shows 10 items with "Show all" toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)