### PR TITLE
feat: Recently Changed Sections on landing page

### DIFF
--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -14,6 +14,41 @@ try {
 } catch {
   // Submodule may not have tags in all environments
 }
+
+// Read recently changed sections from diff manifest
+interface RecentChange { title: string; section: string; path: string; from: string; to: string; }
+let recentChanges: RecentChange[] = [];
+try {
+  const { readFile, readdir } = await import('node:fs/promises');
+  const { join } = await import('node:path');
+  const publicDir = new URL('../../public/diffs/', import.meta.url).pathname;
+  const manifestRaw = await readFile(join(publicDir, 'manifest.json'), 'utf8');
+  const manifest = JSON.parse(manifestRaw) as { pairs: { from: string; to: string; changedSections: number }[] };
+  // Get the most recent pair with changes
+  const recentPair = manifest.pairs.filter(p => p.changedSections > 0).at(-1);
+  if (recentPair) {
+    const pairDir = join(publicDir, `${recentPair.from}_${recentPair.to}`);
+    const titles = await readdir(pairDir).catch(() => [] as string[]);
+    for (const titleDir of titles.slice(0, 5)) {
+      const sections = await readdir(join(pairDir, titleDir)).catch(() => [] as string[]);
+      for (const sectionFile of sections.slice(0, 3)) {
+        const section = sectionFile.replace('.json', '');
+        recentChanges.push({
+          title: titleDir,
+          section,
+          path: `statute/${titleDir}/chapter-1/${section}/`,
+          from: recentPair.from,
+          to: recentPair.to,
+        });
+      }
+      if (recentChanges.length >= 8) break;
+    }
+  }
+} catch {
+  // Diffs may not exist yet
+}
+
+const base = import.meta.env.BASE_URL;
 ---
 
 <BaseLayout
@@ -89,6 +124,27 @@ try {
       Browse all titles &rarr;
     </a>
   </div>
+
+  {recentChanges.length > 0 && (
+    <h2>Recently changed sections</h2>
+    <p class="not-prose mb-3 text-xs text-gray-500 dark:text-gray-400 font-sans">
+      Sections with text changes between {recentChanges[0]?.from.replace('pl-', 'PL ').replace('-', '-')} and {recentChanges[0]?.to.replace('pl-', 'PL ').replace('-', '-')}.
+    </p>
+    <ul class="not-prose mb-6 space-y-1 font-sans text-sm">
+      {recentChanges.map(change => (
+        <li>
+          <a
+            href={`${base}statute/${change.title}/`}
+            class="flex items-center gap-2 rounded px-2 py-1 text-gray-700 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-900"
+          >
+            <span class="h-1.5 w-1.5 rounded-full bg-teal shrink-0" aria-hidden="true"></span>
+            <span class="font-mono text-xs text-slate dark:text-gray-500">{change.title.replace('title-', 'Title ')}</span>
+            <span>{change.section.replace('section-', '§ ')}</span>
+          </a>
+        </li>
+      ))}
+    </ul>
+  )}
 
   <h2>Data source</h2>
   <p>


### PR DESCRIPTION
## Summary
Reads the pre-computed diff manifest at build time to show recently changed sections on the landing page.

- Shows up to 8 sections that changed in the most recent release point pair
- Displays title and section number with teal indicator dot
- Shows which PLs the changes occurred between
- Gracefully hidden when no diffs are available

## Issues
- Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)