### PR TITLE
feat: URL hash deep-linking for title TOC chapters

### DIFF
--- a/apps/web/src/pages/browse/[title].astro
+++ b/apps/web/src/pages/browse/[title].astro
@@ -126,6 +126,7 @@ const autoExpand = sortedChapters.length <= 10;
 
       return (
         <details
+          id={`chapter-${chapterNum}`}
           class="group rounded border border-gray-200 dark:border-gray-800"
           open={autoExpand}
         >
@@ -207,4 +208,21 @@ const autoExpand = sortedChapters.length <= 10;
       );
     })}
   </div>
+
+  <!-- URL hash support: auto-expand chapter from #chapter-N and scroll to it -->
+  <script is:inline>
+    (function () {
+      function openFromHash() {
+        var hash = window.location.hash;
+        if (!hash || !hash.startsWith('#chapter-')) return;
+        var el = document.getElementById(hash.slice(1));
+        if (el && el.tagName === 'DETAILS') {
+          el.open = true;
+          el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      }
+      openFromHash();
+      window.addEventListener('hashchange', openFromHash);
+    })();
+  </script>
 </BaseLayout>


### PR DESCRIPTION
## Summary
Phase 4 of #92 — enables deep-linking to specific chapters in the expandable title TOC.

- Each chapter `<details>` gets `id="chapter-{N}"`
- Inline script auto-opens and smooth-scrolls to the matching chapter on page load
- Listens for `hashchange` for in-page navigation
- Example: `/browse/title-18/#chapter-7` opens and scrolls to Chapter 7

## Issues
- Phase 4 of #92

## Test plan
- [x] `svelte-check` — 0 errors
- [x] `pnpm test` — all pass
- [ ] Manual: navigate to `/browse/title-18/#chapter-7`, verify auto-expand + scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)