### PR TITLE
fix: Hide duplicate h1 in chapter inline content

### DIFF
--- a/apps/web/src/pages/browse/[title]/[chapter].astro
+++ b/apps/web/src/pages/browse/[title]/[chapter].astro
@@ -134,8 +134,8 @@ const activeCount = renderedSections.filter(s => !s.isInactive).length;
           </div>
         </div>
 
-        <!-- Rendered statute content -->
-        <div class="prose prose-gray min-w-0 font-serif dark:prose-invert">
+        <!-- Rendered statute content (hide h1 — we render our own heading above) -->
+        <div class="prose prose-gray min-w-0 font-serif dark:prose-invert [&>h1]:hidden">
           <Content />
         </div>
       </article>


### PR DESCRIPTION
Section headings appeared twice on chapter pages — once from our custom amber heading and once from the rendered markdown h1. Hides the duplicate with `[&>h1]:hidden` on the prose container. Found during live site spot-check.