### PR TITLE
fix: Multipage design review — remove redundancies, add section names, dynamic stats

### DIFF
--- a/apps/web/src/pages/browse/[title].astro
+++ b/apps/web/src/pages/browse/[title].astro
@@ -89,9 +89,15 @@ interface ChapterView {
 const chapters: ChapterView[] = sortedChapters.map(([chapterNum, chapterEntries]) => {
   const activeCount = chapterEntries.filter(e => (e.data.status ?? 'active') === 'active').length;
   const inactiveCount = chapterEntries.length - activeCount;
-  const firstActive = chapterEntries.find(e => (e.data.status ?? 'active') === 'active');
-  const chapterHint = firstActive
-    ? firstActive.data.title.replace(/^Section \S+ - /, '').split(/[;,—]/)[0]?.trim().slice(0, 50)
+  // Derive chapter topic — skip generic titles like "Definitions", "Short title", "Purpose"
+  const genericTitles = /^(Definitions|Short title|Purpose|General provisions|Findings|Congressional|Establishment|Authorization)/i;
+  const activeEntries = chapterEntries.filter(e => (e.data.status ?? 'active') === 'active');
+  const hintEntry = activeEntries.find(e => {
+    const clean = e.data.title.replace(/^Section \S+ - /, '');
+    return !genericTitles.test(clean);
+  }) ?? activeEntries[0];
+  const chapterHint = hintEntry
+    ? hintEntry.data.title.replace(/^Section \S+ - /, '').split(/[;,—]/)[0]?.trim().slice(0, 60)
     : undefined;
 
   const sections: SectionView[] = chapterEntries.map(entry => {
@@ -168,18 +174,15 @@ const chapters: ChapterView[] = sortedChapters.map(([chapterNum, chapterEntries]
           <svg class="h-3 w-3 shrink-0 text-gray-400 transition-transform group-open:rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
           </svg>
-          <span class="font-mono text-xs text-slate dark:text-gray-500 w-10 shrink-0 text-right">
-            Ch. {ch.chapterNum}
-          </span>
           <span class="flex items-baseline gap-2 min-w-0">
             <a
               href={`${base}browse/title-${titleNum}/chapter-${ch.chapterNum}/`}
               class="shrink-0 font-medium text-navy hover:underline dark:text-gray-200"
             >
-              Chapter {ch.chapterNum}
+              Ch. {ch.chapterNum}
             </a>
             {ch.chapterHint && (
-              <span class="truncate text-xs text-gray-400 dark:text-gray-600 hidden sm:inline">{ch.chapterHint}</span>
+              <span class="truncate text-xs text-gray-400 dark:text-gray-600">&mdash; {ch.chapterHint}</span>
             )}
           </span>
           <span class="ml-auto flex items-center gap-2 text-xs text-gray-400">

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -17,7 +17,7 @@ try {
 }
 
 // Read recently changed sections from diff manifest and resolve actual URLs
-interface RecentChange { title: string; section: string; entryId: string; from: string; to: string; }
+interface RecentChange { title: string; section: string; entryId: string; sectionName: string; from: string; to: string; }
 let recentChanges: RecentChange[] = [];
 try {
   const { readFile, readdir } = await import('node:fs/promises');
@@ -29,10 +29,10 @@ try {
   if (recentPair) {
     // Build a lookup from title+section to entry ID using content collection
     const allEntries = await getCollection('statutes');
-    const entryLookup = new Map<string, string>();
+    const entryLookup = new Map<string, { id: string; name: string }>();
     for (const entry of allEntries) {
       const key = `title-${entry.data.usc_title}/section-${entry.data.usc_section}`;
-      entryLookup.set(key, entry.id);
+      entryLookup.set(key, { id: entry.id, name: entry.data.title.replace(/^Section \S+ - /, '') });
     }
 
     const pairDir = join(publicDir, `${recentPair.from}_${recentPair.to}`);
@@ -42,12 +42,13 @@ try {
       for (const sectionFile of sections.slice(0, 3)) {
         const section = sectionFile.replace('.json', '');
         const key = `${titleDir}/${section}`;
-        const entryId = entryLookup.get(key);
-        if (entryId) {
+        const found = entryLookup.get(key);
+        if (found) {
           recentChanges.push({
             title: titleDir,
             section,
-            entryId,
+            entryId: found.id,
+            sectionName: found.name,
             from: recentPair.from,
             to: recentPair.to,
           });
@@ -58,6 +59,17 @@ try {
   }
 } catch {
   // Diffs may not exist yet
+}
+
+// Compute stats from content collection (reuses already-loaded data when available)
+let sectionCount = 59954; // fallback
+let titleCount = 54; // fallback
+try {
+  const stats = await getCollection('statutes');
+  sectionCount = stats.length;
+  titleCount = new Set(stats.map(e => e.data.usc_title)).size;
+} catch {
+  // Use fallback values
 }
 
 const base = import.meta.env.BASE_URL;
@@ -78,11 +90,11 @@ const base = import.meta.env.BASE_URL;
   <!-- Quick stats -->
   <div class="not-prose my-6 flex flex-wrap gap-4">
     <div class="rounded-lg border border-teal/30 bg-teal/5 px-5 py-3 text-center font-sans">
-      <p class="text-2xl font-bold text-teal">54</p>
+      <p class="text-2xl font-bold text-teal">{titleCount}</p>
       <p class="mt-0.5 text-xs text-slate dark:text-gray-400">Titles</p>
     </div>
     <div class="rounded-lg border border-teal/30 bg-teal/5 px-5 py-3 text-center font-sans">
-      <p class="text-2xl font-bold text-teal">59,954</p>
+      <p class="text-2xl font-bold text-teal">{sectionCount.toLocaleString()}</p>
       <p class="mt-0.5 text-xs text-slate dark:text-gray-400">Sections</p>
     </div>
     <div class="rounded-lg border border-teal/30 bg-teal/5 px-5 py-3 text-center font-sans">
@@ -150,8 +162,9 @@ const base = import.meta.env.BASE_URL;
             class="flex items-center gap-2 rounded px-2 py-1 text-gray-700 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-900"
           >
             <span class="h-1.5 w-1.5 rounded-full bg-teal shrink-0" aria-hidden="true"></span>
-            <span class="font-mono text-xs text-slate dark:text-gray-500">{change.title.replace('title-', 'Title ')}</span>
-            <span>{change.section.replace('section-', '§ ')}</span>
+            <span class="font-mono text-xs text-slate dark:text-gray-500 shrink-0">{change.title.replace('title-', 'Title ')}</span>
+            <span class="shrink-0">{change.section.replace('section-', '§ ')}</span>
+            <span class="truncate text-xs text-gray-400 dark:text-gray-500">{change.sectionName}</span>
           </a>
         </li>
       ))}


### PR DESCRIPTION
4 fixes from full 6-agent consensus vote (approved 3-2):

1. **Remove redundant chapter labels**: "Ch. 1 Chapter 1" → "Ch. 1 — topic hint"
2. **Smarter chapter hints**: Skip generic titles (Definitions, Short title) and use first substantive section
3. **Section names on landing page**: "Title 10 § 101 — Definitions" instead of just "§ 101"
4. **Dynamic stats**: Compute title/section counts from content collection, not hardcoded

Addresses contrarian feedback: generic title skipping prevents mislabeling chapters.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)