### PR TITLE
feat: Desktop focus mode for distraction-free reading

### DIFF
--- a/apps/web/src/layouts/BaseLayout.astro
+++ b/apps/web/src/layouts/BaseLayout.astro
@@ -52,11 +52,14 @@ const titleEntries = Object.entries(TITLE_NAMES)
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://api.github.com;" />
     <title>{title === 'US Code Tracker' ? title : `${title} | US Code Tracker`}</title>
     <script is:inline>
-      // Apply theme before render to prevent flash
+      // Apply theme and focus mode before render to prevent flash
       (function () {
-        const stored = localStorage.getItem('theme');
+        var stored = localStorage.getItem('theme');
         if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
           document.documentElement.classList.add('dark');
+        }
+        if (localStorage.getItem('focus-mode') === 'true') {
+          document.documentElement.classList.add('focus-mode');
         }
       })();
     </script>
@@ -74,7 +77,20 @@ const titleEntries = Object.entries(TITLE_NAMES)
           </a>
           <span class="hidden text-xs text-slate dark:text-gray-500 lg:inline">Current through PL 119-73</span>
           <div class="flex items-center gap-2 lg:w-full lg:flex-col lg:items-stretch">
-            <ThemeToggle client:load />
+            <div class="flex items-center gap-2 lg:w-full">
+              <ThemeToggle client:load />
+              <button
+                id="focus-toggle"
+                class="hidden lg:inline-flex items-center gap-1 rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
+                aria-label="Toggle focus mode"
+                title="Hide sidebar for distraction-free reading"
+              >
+                <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />
+                </svg>
+                <span class="focus-label">Focus</span>
+              </button>
+            </div>
             <SearchBar client:load />
           </div>
         </div>
@@ -190,6 +206,23 @@ const titleEntries = Object.entries(TITLE_NAMES)
             li.style.display = match ? '' : 'none';
           }
         });
+        // Focus mode toggle
+        var focusBtn = document.getElementById('focus-toggle');
+        if (focusBtn) {
+          var label = focusBtn.querySelector('.focus-label');
+          function updateFocusLabel() {
+            var active = document.documentElement.classList.contains('focus-mode');
+            if (label) label.textContent = active ? 'Exit' : 'Focus';
+            focusBtn.setAttribute('aria-label', active ? 'Exit focus mode' : 'Enter focus mode');
+          }
+          updateFocusLabel();
+          focusBtn.addEventListener('click', function () {
+            document.documentElement.classList.toggle('focus-mode');
+            var active = document.documentElement.classList.contains('focus-mode');
+            localStorage.setItem('focus-mode', String(active));
+            updateFocusLabel();
+          });
+        }
       })();
     </script>
     <BackToTop client:load />

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -154,6 +154,22 @@
   }
 }
 
+/* Focus mode — hide sidebar, center content for distraction-free reading */
+.focus-mode aside {
+  display: none !important;
+}
+
+.focus-mode main {
+  max-width: 72ch;
+  margin: 0 auto;
+}
+
+@media (min-width: 1280px) {
+  .focus-mode main {
+    max-width: 80ch;
+  }
+}
+
 /* Print styles — page breaks, clean layout */
 @media print {
   aside, footer, nav, .not-prose { display: none !important; }


### PR DESCRIPTION
Adds a "Focus" button to the sidebar that hides navigation and centers content at optimal reading width. Persists in localStorage. Desktop only (hidden on mobile where sidebar already collapses).

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)