### PR TITLE
refactor: Remove focus mode (consensus 4-1 to remove)

### DIFF
--- a/apps/web/src/layouts/BaseLayout.astro
+++ b/apps/web/src/layouts/BaseLayout.astro
@@ -52,14 +52,11 @@ const titleEntries = Object.entries(TITLE_NAMES)
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://api.github.com;" />
     <title>{title === 'US Code Tracker' ? title : `${title} | US Code Tracker`}</title>
     <script is:inline>
-      // Apply theme and focus mode before render to prevent flash
+      // Apply theme before render to prevent flash
       (function () {
         var stored = localStorage.getItem('theme');
         if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
           document.documentElement.classList.add('dark');
-        }
-        if (localStorage.getItem('focus-mode') === 'true') {
-          document.documentElement.classList.add('focus-mode');
         }
       })();
     </script>
@@ -77,20 +74,7 @@ const titleEntries = Object.entries(TITLE_NAMES)
           </a>
           <span class="hidden text-xs text-slate dark:text-gray-500 lg:inline">Current through PL 119-73</span>
           <div class="flex items-center gap-2 lg:w-full lg:flex-col lg:items-stretch">
-            <div class="flex items-center gap-2 lg:w-full">
-              <ThemeToggle client:load />
-              <button
-                id="focus-toggle"
-                class="hidden lg:inline-flex items-center gap-1 rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
-                aria-label="Toggle focus mode"
-                title="Hide sidebar for distraction-free reading"
-              >
-                <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />
-                </svg>
-                <span class="focus-label">Focus</span>
-              </button>
-            </div>
+            <ThemeToggle client:load />
             <SearchBar client:load />
           </div>
         </div>
@@ -206,42 +190,8 @@ const titleEntries = Object.entries(TITLE_NAMES)
             li.style.display = match ? '' : 'none';
           }
         });
-        // Focus mode toggle
-        function toggleFocusMode() {
-          document.documentElement.classList.toggle('focus-mode');
-          var active = document.documentElement.classList.contains('focus-mode');
-          localStorage.setItem('focus-mode', String(active));
-          var focusBtn = document.getElementById('focus-toggle');
-          if (focusBtn) {
-            var label = focusBtn.querySelector('.focus-label');
-            if (label) label.textContent = active ? 'Exit' : 'Focus';
-            focusBtn.setAttribute('aria-label', active ? 'Exit focus mode' : 'Enter focus mode');
-          }
-        }
-        var focusBtn = document.getElementById('focus-toggle');
-        if (focusBtn) {
-          var label = focusBtn.querySelector('.focus-label');
-          var active = document.documentElement.classList.contains('focus-mode');
-          if (label) label.textContent = active ? 'Exit' : 'Focus';
-          focusBtn.addEventListener('click', toggleFocusMode);
-        }
-        var focusExit = document.getElementById('focus-exit');
-        if (focusExit) {
-          focusExit.addEventListener('click', toggleFocusMode);
-        }
       })();
     </script>
-    <!-- Floating exit button for focus mode (visible only when sidebar is hidden) -->
-    <button
-      id="focus-exit"
-      class="fixed top-4 left-4 z-50 hidden items-center gap-1 rounded-lg border border-gray-300 bg-white px-3 py-1.5 font-sans text-xs text-gray-700 shadow-md hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
-      aria-label="Exit focus mode"
-    >
-      <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />
-      </svg>
-      Exit Focus
-    </button>
     <BackToTop client:load />
   </body>
 </html>

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -154,25 +154,6 @@
   }
 }
 
-/* Focus mode — hide sidebar, center content for distraction-free reading */
-.focus-mode aside {
-  display: none !important;
-}
-
-.focus-mode main {
-  max-width: 72ch;
-  margin: 0 auto;
-}
-
-.focus-mode #focus-exit {
-  display: inline-flex !important;
-}
-
-@media (min-width: 1280px) {
-  .focus-mode main {
-    max-width: 80ch;
-  }
-}
 
 /* Print styles — page breaks, clean layout */
 @media print {


### PR DESCRIPTION
Consensus voted 4-1 to remove focus mode. It added JS overhead, caused a UX trap bug, and duplicates browser reader mode. Removes all focus mode code.