### PR TITLE
fix(a11y): Chapter description contrast for WCAG AA compliance

### DIFF
--- a/apps/web/src/pages/browse/[title].astro
+++ b/apps/web/src/pages/browse/[title].astro
@@ -182,7 +182,7 @@ const chapters: ChapterView[] = sortedChapters.map(([chapterNum, chapterEntries]
               Ch. {ch.chapterNum}
             </a>
             {ch.chapterHint && (
-              <span class="truncate text-xs text-gray-400 dark:text-gray-600">&mdash; {ch.chapterHint}</span>
+              <span class="truncate text-xs text-slate dark:text-gray-400">&mdash; {ch.chapterHint}</span>
             )}
           </span>
           <span class="ml-auto flex items-center gap-2 text-xs text-gray-400">


### PR DESCRIPTION
Chapter hint text failed WCAG AA contrast ratio. Changed from gray-400 to slate. Other QA items verified as already fixed.