### PR TITLE
fix(mobile): Responsiveness for chapter pages and statutory text

### DIFF
--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -129,10 +129,33 @@
   border-color: var(--color-gray-700, #334155);
 }
 
-/* Mobile prose — tighter width, keep 19px font (Gov.uk accessibility: same size all screens) */
+/* Word wrapping for long statutory references */
+.prose {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+/* Mobile prose — tighter width, reduced nesting */
 @media (max-width: 768px) {
   .prose {
-    max-width: min(90vw, 65ch);
+    max-width: min(92vw, 65ch);
+  }
+
+  /* Reduce nested list indentation on narrow screens */
+  .prose ul ul {
+    padding-left: 1rem;
+  }
+  .prose ul ul ul {
+    padding-left: 0.75rem;
+  }
+  .prose ul ul ul ul {
+    padding-left: 0.5rem;
+  }
+
+  /* Anchor link clearance for sticky header on mobile */
+  [id^="section-"],
+  [id^="subsec-"] {
+    scroll-margin-top: 5rem;
   }
 }
 
@@ -149,6 +172,11 @@
 
 :where(.dark, .dark *) .sticky-section-header {
   background: var(--color-gray-950, #030712);
+}
+
+/* Anchor link scroll clearance for sticky headers */
+[id^="section-"] {
+  scroll-margin-top: 4rem;
 }
 
 /* Mobile breadcrumb: hide middle items, show only first + last */


### PR DESCRIPTION
Prevents horizontal overflow from deep list nesting and long statutory references on mobile. Adds scroll-margin-top for anchor links.