### PR TITLE
fix(scorecard): pin codeql-action/upload-sarif to commit SHA

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           name: SARIF file
           path: results.sarif
-      - uses: github/codeql-action/upload-sarif@3b1a19a80ab047f35cbb237b5bd9bdc1e14f166c # v3
+      - uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- The scheduled OpenSSF Scorecard run was still failing after #163 with `imposter commit: 3b1a19a80ab047f35cbb237b5bd9bdc1e14f166c does not belong to github/codeql-action/upload-sarif`.
- That SHA is the annotated-tag-object for `v3`, not a commit. OSSF's sigstore-backed webapp verification rejects tag-object SHAs.
- Pin to `7fd177fa680c9881b53cdab4d346d32574c9f7f4` (the actual commit for `v3.35.4`, the current latest v3 release).

## Test plan
- [ ] CI build passes on this PR.
- [ ] After merge, trigger `workflow_dispatch` on `scorecard.yml` and confirm: (a) the imposter-commit error disappears, (b) the run completes with `conclusion: success`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)