### PR TITLE
fix(ci): tighten token permissions + add CodeQL SAST workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "30 6 * * 1"
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,16 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
+permissions: read-all
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/sync-law.yml
+++ b/.github/workflows/sync-law.yml
@@ -9,13 +9,14 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
-permissions:
-  contents: write
+permissions: read-all
 
 jobs:
   sync:
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
     timeout-minutes: 60
+    permissions:
+      contents: write
     steps:
       # Step 1: Checkout pipeline code
       - name: Checkout us-code-tracker


### PR DESCRIPTION
## Summary
Addresses two open OpenSSF Scorecard findings (Token-Permissions = 0/10, SAST = 0/10) plus a latent compatibility issue flagged by the prior contrarian review.

### Changes
- **release.yml & sync-law.yml**: move `contents: write` from workflow-level to job-level. Top-level now `read-all` so unrelated steps can't escalate. Matches the pattern already used by `ci.yml` and `scorecard.yml`.
- **codeql.yml** (new): CodeQL javascript-typescript analysis with `security-and-quality` query suite. Runs on push/PR to main + weekly cron. `security-events: write` is scoped to the analyze job only — required for SARIF upload now that top-level permissions are locked down. Pinned to v3.35.4 commit SHA (same SHA already used in scorecard.yml after #164).
- **release.yml env**: add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` so the `softprops/action-gh-release@v3` step (Node 24 runtime, bumped in #163) doesn't fail on the next tag push. CI already sets this; release.yml didn't because it's tag-triggered and hasn't run since the bump.

### Expected Scorecard delta
- Token-Permissions: 0/10 → ~10/10
- SAST: 0/10 → 10/10
- Total: 5.2 → ~7.0

## Test plan
- [ ] CI build passes on this PR (no app code touched)
- [ ] CodeQL workflow runs to completion on this PR's push event
- [ ] Manually trigger Scorecard \`workflow_dispatch\` after merge; confirm Token-Permissions and SAST scores improve

🤖 Generated with [Claude Code](https://claude.com/claude-code)