### PR TITLE
fix(web): replace regex HTML sanitization with sanitize-html

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,11 +21,13 @@
     "@tailwindcss/vite": "4.1.18",
     "astro": "^6.3.1",
     "pagefind": "^1.5.2",
+    "sanitize-html": "^2.17.3",
     "svelte": "^5.55.5",
     "tailwindcss": "4.1.18"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
+    "@types/sanitize-html": "^2.16.1",
     "typescript": "^5.8.0",
     "vitest": "^4.1.6"
   }

--- a/apps/web/src/__tests__/github.test.ts
+++ b/apps/web/src/__tests__/github.test.ts
@@ -24,8 +24,12 @@ describe('sanitizeContent', () => {
     expect(sanitizeContent('before<!-- hidden instruction -->after')).toBe('beforeafter');
   });
 
-  it('decodes HTML entities and re-strips', () => {
-    expect(sanitizeContent('&lt;script&gt;alert(1)&lt;/script&gt;')).toBe('alert(1)');
+  it('keeps encoded entities encoded (cannot bypass the parser)', () => {
+    // sanitize-html parses as HTML and preserves `&lt;` etc. as entities — so
+    // the rendered output is literal text, never a re-parsed <script> element.
+    const out = sanitizeContent('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(out).not.toContain('<');
+    expect(out).not.toContain('>');
   });
 
   it('handles nested/malformed tags', () => {

--- a/apps/web/src/lib/github.ts
+++ b/apps/web/src/lib/github.ts
@@ -1,4 +1,5 @@
 import { Octokit } from "@octokit/rest";
+import sanitizeHtml from "sanitize-html";
 
 export interface CommitInfo {
   sha: string;
@@ -123,35 +124,28 @@ export async function getFileAtRef(
 }
 
 /**
- * Strip HTML tags and dangerous content to prevent XSS.
- * Handles: tags, encoded entities, script/style blocks, event handlers.
- * For untrusted content only — trusted Astro/Svelte output doesn't need this.
+ * Strip all HTML tags to plain text.
+ * Uses sanitize-html (a real HTML parser), not regex, so encoded entities and
+ * malformed/nested tags can't bypass it. For displaying untrusted content as text.
  */
 export function sanitizeContent(raw: string): string {
-  return raw
-    // Remove script/style blocks entirely (including content)
-    .replace(/<script[\s\S]*?<\/script>/gi, "")
-    .replace(/<style[\s\S]*?<\/style>/gi, "")
-    // Remove HTML comments (can contain instructions/hidden content)
-    .replace(/<!--[\s\S]*?-->/g, "")
-    // Remove all HTML tags
-    .replace(/<[^>]*>/g, "")
-    // Decode common HTML entities
-    .replace(/&lt;/g, "<").replace(/&gt;/g, ">")
-    .replace(/&amp;/g, "&").replace(/&quot;/g, '"')
-    .replace(/&#x27;/g, "'").replace(/&#x2F;/g, "/")
-    // Re-strip any tags that were hiding inside encoded entities
-    .replace(/<[^>]*>/g, "");
+  return sanitizeHtml(raw, {
+    allowedTags: [],
+    allowedAttributes: {},
+    disallowedTagsMode: "discard",
+  });
 }
 
-/** Sanitize Pagefind excerpt HTML — allow only <mark> highlight tags */
+/**
+ * Sanitize Pagefind excerpt HTML, preserving only <mark> highlight tags.
+ * Used in client-side search results rendered via {@html ...}.
+ */
 export function sanitizeExcerpt(html: string): string {
-  // Pagefind wraps matches in <mark> tags — preserve those, strip everything else
-  return html
-    .replace(/<script[\s\S]*?<\/script>/gi, "")
-    .replace(/<style[\s\S]*?<\/style>/gi, "")
-    .replace(/<!--[\s\S]*?-->/g, "")
-    .replace(/<(?!\/?mark[ >])[^>]*>/gi, "");
+  return sanitizeHtml(html, {
+    allowedTags: ["mark"],
+    allowedAttributes: {},
+    disallowedTagsMode: "discard",
+  });
 }
 
 /** Format a pl-* tag name into a human-readable label */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       pagefind:
         specifier: ^1.5.2
         version: 1.5.2
+      sanitize-html:
+        specifier: ^2.17.3
+        version: 2.17.3
       svelte:
         specifier: ^5.55.5
         version: 5.55.5
@@ -89,6 +92,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.9
         version: 0.9.9(prettier@3.8.1)(typescript@5.9.3)
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
@@ -1245,6 +1251,9 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -1687,6 +1696,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -1931,6 +1944,9 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
@@ -1997,6 +2013,10 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
@@ -2483,6 +2503,9 @@ packages:
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
 
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
@@ -2635,6 +2658,9 @@ packages:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  sanitize-html@2.17.3:
+    resolution: {integrity: sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==}
 
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
@@ -4124,6 +4150,10 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
+
   '@types/trusted-types@2.0.7': {}
 
   '@types/unist@3.0.3': {}
@@ -4688,6 +4718,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   env-paths@2.2.1: {}
 
   error-ex@1.3.4:
@@ -5035,6 +5067,13 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-cache-semantics@4.2.0: {}
 
   ignore@5.3.2: {}
@@ -5075,6 +5114,8 @@ snapshots:
   is-obj@2.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-plain-object@5.0.0: {}
 
   is-reference@3.0.3:
     dependencies:
@@ -5693,6 +5734,8 @@ snapshots:
       unist-util-visit-children: 3.0.0
       vfile: 6.0.3
 
+  parse-srcset@1.0.2: {}
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
@@ -5887,6 +5930,15 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.60.2
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
+
+  sanitize-html@2.17.3:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 10.1.0
+      is-plain-object: 5.0.0
+      parse-srcset: 1.0.2
+      postcss: 8.5.10
 
   sax@1.6.0: {}
 


### PR DESCRIPTION
## Summary
Closes the remaining 15 CodeQL findings in `apps/web/src/lib/github.ts`:
- 12 × `js/incomplete-multi-character-sanitization`
- 2 × `js/bad-tag-filter`
- 1 × `js/double-escaping`

All flagged the fundamental fact that regex-based HTML stripping is bypass-able. `sanitize-html` (v2.17) uses a real HTML parser (htmlparser2) so malformed/nested tags and encoded entities cannot escape the allowlist.

### Two configs preserve existing contracts
- `sanitizeContent` → `allowedTags: []` (plain text). Used by `DiffViewer.svelte` for content fetched from the us-code repo via GitHub API.
- `sanitizeExcerpt` → `allowedTags: ['mark']` (Pagefind highlight wrapper). Rendered via `{@html ...}` in `SearchBar.svelte`.

### Test change worth flagging
One test changed expectation: the prior regex would decode `&lt;script&gt;...` then strip — `sanitize-html` preserves entities as entities, which is the actually-safe behavior (entity-encoded text renders as literal text, never as parsed HTML). Test updated to assert no raw `<`/`>` in the output rather than the specific decoded form — captures the security property without coupling to the legacy regex's "decode then strip" pattern.

## Test plan
- [x] `pnpm install` resolves cleanly (added: sanitize-html 2.17.3 + @types/sanitize-html 2.16.1)
- [x] `pnpm build` (Astro SSG + Pagefind index) passes — sanitize-html survives the SSR/bundle path
- [x] `pnpm test` (269 tests) green
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [ ] CI build passes
- [ ] Post-merge CodeQL re-scan: 15 alerts in github.ts should clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)