### PR TITLE
ci: add workflow_dispatch trigger to codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   schedule:
     - cron: "30 6 * * 1"
+  workflow_dispatch:
 
 permissions: read-all
 


### PR DESCRIPTION
Closes #172. One-line addition; lets maintainers manually rerun CodeQL via the Actions UI or `gh workflow run codeql.yml --ref main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)