### PR TITLE
security: pin CI to ubuntu-latest, drop self-hosted runner indirection

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/sync-law.yml
+++ b/.github/workflows/sync-law.yml
@@ -13,7 +13,7 @@ permissions: read-all
 
 jobs:
   sync:
-    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: write


### PR DESCRIPTION
Part of the cross-repo self-hosted-runner removal (williamzujkowski/homelab-iac#747).

`deploy-site.yml` (build) and `sync-law.yml` (sync, `contents: write`) used `runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}`. The repo variable `RUNNER_LABEL=self-hosted` routed these **public-repo** jobs to a homelab self-hosted runner — a fork-PR code-execution risk on the lab host.

- The `RUNNER_LABEL` variable has already been **deleted** (jobs now fall back to `ubuntu-latest`).
- This PR removes the `vars.RUNNER_LABEL` indirection entirely so the self-hosted path can't be re-enabled by re-adding the variable.

Both jobs are standard GitHub-hosted work (pnpm build, static-site deploy, statute sync) — no self-hosted dependency. The previously-registered `homelab-r910` runner is already deregistered (0 runners on this repo).