### PR TITLE
fix(ci): make @civic-source/* resolvable for sync-law.yml inline scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     }
   },
   "devDependencies": {
+    "@civic-source/annotator": "workspace:*",
+    "@civic-source/fetcher": "workspace:*",
+    "@civic-source/transformer": "workspace:*",
     "@commitlint/cli": "^21.0.1",
     "@commitlint/config-conventional": "^21.0.1",
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     devDependencies:
+      '@civic-source/annotator':
+        specifier: workspace:*
+        version: link:packages/annotator
+      '@civic-source/fetcher':
+        specifier: workspace:*
+        version: link:packages/fetcher
+      '@civic-source/transformer':
+        specifier: workspace:*
+        version: link:packages/transformer
       '@commitlint/cli':
         specifier: ^21.0.1
         version: 21.0.1(@types/node@25.5.0)(conventional-commits-parser@6.3.0)(typescript@6.0.3)


### PR DESCRIPTION
Closes #194.

## Problem
The **Sync US Code** workflow failed on its first real run ([27901575756](https://github.com/civic-source/us-code-tracker/actions/runs/27901575756)) with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@civic-source/fetcher'
```

The inline `node --input-type=module <<'SCRIPT'` steps run **from the repo root** and import `@civic-source/fetcher` / `/transformer` / `/annotator`. pnpm only symlinks a workspace package into the `node_modules` of packages that **declare** it as a dependency — and the root `package.json` declared none — so the imports could not resolve and the step died before any network call.

## Fix
Declare the three imported packages as root `devDependencies` (`workspace:*`). pnpm then symlinks them into the **root** `node_modules`, so they resolve when the scripts execute from the repo root. No changes to the workflow's relative paths required.

```diff
   "devDependencies": {
+    "@civic-source/annotator": "workspace:*",
+    "@civic-source/fetcher": "workspace:*",
+    "@civic-source/transformer": "workspace:*",
```

## Verification (local)
1. Reproduced: `node -e "import('@civic-source/fetcher')"` from repo root → `ERR_MODULE_NOT_FOUND`.
2. Applied fix → `pnpm install && pnpm build`.
3. Re-ran the workflow's exact three-import block from repo root → **all imports resolved**.

## Follow-up (not in this PR)
- A CI smoke step that runs these imports the way the workflow does, so script-resolution breakage is caught on PRs (noted in #194).
- The longer-term option of wiring the workflow to the existing-but-unused `@civic-source/pipeline` `orchestrate()` (de-duping the inline heredoc logic) remains open in #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)