### PR TITLE
fix(web): escape JSON-LD to prevent </script> breakout XSS (#200 H1)

### DIFF
--- a/apps/web/src/pages/statute/[...slug].astro
+++ b/apps/web/src/pages/statute/[...slug].astro
@@ -156,7 +156,7 @@ const readingTimeMin = Math.max(1, Math.round(wordCount / 200));
     "url": `https://civic-source.github.io${base}statute/${entry.id}/`,
     "dateModified": generated_at?.split('T')[0] ?? "2026-03-30",
     "publisher": { "@type": "Organization", "name": "Office of the Law Revision Counsel", "url": "https://uscode.house.gov/" }
-  })} />
+  }).replace(/</g, '\\u003c').replace(/>/g, '\\u003e').replace(/&/g, '\\u0026')} />
 
   <!-- Breadcrumbs -->
   <Breadcrumbs items={[


### PR DESCRIPTION
Addresses the **H1** finding in #200 (confirmed).

## Problem
`apps/web/src/pages/statute/[...slug].astro:147` rendered Schema.org JSON-LD via `set:html={JSON.stringify(...)}`. `JSON.stringify` does not escape `<` / `>` / `&`, and `set:html` adds no escaping. A statute `title`/`classification` (sourced from OLRC XML→markdown) containing `</script><img src=x onerror=alert(1)>` would close the `<script type="application/ld+json">` element and inject live HTML — not blocked by the site's `script-src 'unsafe-inline'` CSP.

## Fix
Apply the standard safe-JSON-in-`<script>` escaping to the serialized string:
```js
}).replace(/</g, '\\u003c').replace(/>/g, '\\u003e').replace(/&/g, '\\u0026')} />
```

## Verification
- Escaping a payload `Evil </script><img src=x onerror=alert(1)>` → output contains **no** literal `</script>`; `JSON.parse` round-trips identically (still valid JSON-LD).
- Confirmed this is the **only** `set:html={JSON.stringify(...)}` sink in the app.
- `pnpm --filter @civic-source/web build` passes.

Remaining items from #200 (H2 markdown-body sanitization, M1 CSP `'unsafe-inline'`) are tracked separately in that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)