### PR TITLE
fix(fetcher): harden against SSRF and oversized downloads (closes #201)

### DIFF
--- a/packages/fetcher/src/__tests__/fetcher.test.ts
+++ b/packages/fetcher/src/__tests__/fetcher.test.ts
@@ -165,6 +165,21 @@ describe('parseReleasePoints', () => {
     expect(points[0]?.publicLaw).toBe('');
   });
 
+  it('does not produce an off-host uslmUrl for an absolute foreign-host href (SSRF)', () => {
+    // An attacker-controlled page that points a release-point link at a
+    // foreign host must never yield a uslmUrl that fetchXml would fetch.
+    const html = `
+      <h2>Public Law 118-200 (11/15/2024)</h2>
+      <a href="https://evil.example/download/releasepoints/us/pl/1/1/xml_usc18@1-1.zip">Evil</a>
+    `;
+    const points = parseReleasePoints(html);
+    // The link is either skipped or rewritten to the OLRC host — never evil.example.
+    for (const p of points) {
+      expect(p.uslmUrl).not.toContain('evil.example');
+      expect(p.uslmUrl.startsWith('https://uscode.house.gov/')).toBe(true);
+    }
+  });
+
   it('does not catastrophically backtrack on malformed input (CodeQL js/polynomial-redos)', () => {
     // Long string of repeated non-quote chars that look like an unclosed href.
     // The old [^"]* prefix would let the engine try every cut point.
@@ -373,6 +388,22 @@ describe('OlrcFetcher', () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.message).toContain('not a valid ZIP');
+    }
+  });
+
+  it('fetchXml rejects a response whose Content-Length exceeds the size cap', async () => {
+    // Advertise a body far larger than MAX_DOWNLOAD_BYTES (300 MiB).
+    const oversized = String(314572800 + 1);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('PK', { status: 200, headers: { 'content-length': oversized } })
+    );
+
+    const rp: ReleasePoint = { title: '42', publicLaw: 'PL 118-200', dateET: '2024-01-01T00:00:00Z', uslmUrl: 'https://example.com/t42.zip', sha256Hash: '0'.repeat(64) };
+    const fetcher = new OlrcFetcher({ logger });
+    const result = await fetcher.fetchXml(rp);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('size limit');
     }
   });
 

--- a/packages/fetcher/src/constants.ts
+++ b/packages/fetcher/src/constants.ts
@@ -22,6 +22,16 @@ export function allTitlesXmlUrl(congress: string, law: string): string {
   return `${OLRC_RELEASE_POINTS_URL}us/pl/${congress}/${law}/xml_uscAll@${congress}-${law}.zip`;
 }
 
+/**
+ * Maximum number of bytes to accept from a single download.
+ *
+ * Guards CI runners against OOM from a maliciously or accidentally huge
+ * response. The bound is deliberately generous: the all-titles USC archive
+ * can be ~100-150 MB, so 300 MiB leaves ample headroom for legitimate
+ * downloads while still capping runaway responses.
+ */
+export const MAX_DOWNLOAD_BYTES = 314572800; // 300 MiB
+
 /** Path for hash storage relative to working directory */
 export const HASH_STORE_DIR = '.openlaw-git';
 export const HASH_STORE_FILE = 'hashes.json';

--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -1,13 +1,35 @@
 import { createHash } from 'node:crypto';
 import { type IUsCodeFetcher, type ReleasePoint, type Result, ok, err } from '@civic-source/types';
 import { type Logger, createLogger, fetchWithRetry as sharedFetchWithRetry } from '@civic-source/shared';
-import { OLRC_DOWNLOAD_PAGE, OLRC_PRIOR_RELEASE_POINTS_PAGE } from './constants.js';
+import {
+  OLRC_BASE_URL,
+  OLRC_DOWNLOAD_PAGE,
+  OLRC_PRIOR_RELEASE_POINTS_PAGE,
+  MAX_DOWNLOAD_BYTES,
+} from './constants.js';
 import { HashStore } from './hash-store.js';
 import { FetcherMetrics } from './metrics.js';
 
 /** Compute SHA-256 hex digest of a buffer */
 export function sha256(data: Buffer): string {
   return createHash('sha256').update(data).digest('hex');
+}
+
+/**
+ * Inspect a response's Content-Length header and reject up-front if it
+ * advertises a body larger than MAX_DOWNLOAD_BYTES. This is the primary guard
+ * against runner OOM: it avoids ever reading an oversized body into memory.
+ *
+ * Returns true when the response is over the cap (caller should error).
+ * A missing or unparseable Content-Length returns false — the post-read
+ * length check provides defense-in-depth for those cases.
+ */
+export function exceedsContentLengthLimit(response: Response): boolean {
+  const header = response.headers.get('content-length');
+  if (header === null) return false;
+  const declared = Number(header);
+  if (!Number.isFinite(declared)) return false;
+  return declared > MAX_DOWNLOAD_BYTES;
 }
 
 /**
@@ -118,9 +140,16 @@ export function parseReleasePoints(html: string): ReleasePoint[] {
   const currentRelease = parseCurrentRelease(html);
 
   // Match links like: /download/releasepoints/us/pl/118/42/xml_usc42@118-200.zip
+  //
+  // SSRF hardening: only accept OLRC server-relative hrefs (the form the OLRC
+  // pages actually emit). We deliberately do NOT accept an absolute-URL prefix
+  // here: allowing one would let an href to an arbitrary host become a
+  // uslmUrl that fetchXml then fetches verbatim. Because every match is a bare
+  // path, fullUrl below is always anchored to the OLRC host.
+  //
   // Anchor segments to non-slash/non-quote chars so we don't get polynomial
   // backtracking on malformed input (CodeQL js/polynomial-redos).
-  const linkPattern = /href="((?:https?:\/\/[^"/]+)?\/download\/releasepoints\/us\/pl\/(\d+)\/([^/"]+)\/xml_usc[^"/]+\.zip)"/g;
+  const linkPattern = /href="(\/download\/releasepoints\/us\/pl\/(\d+)\/([^/"]+)\/xml_usc[^"/]+\.zip)"/g;
   let match: RegExpExecArray | null;
 
   // Extract unique title numbers from XML download links
@@ -138,9 +167,10 @@ export function parseReleasePoints(html: string): ReleasePoint[] {
     if (!title || seen.has(title)) continue;
     seen.add(title);
 
-    const fullUrl = path.startsWith('http')
-      ? path
-      : `https://uscode.house.gov${path}`;
+    // path is always an OLRC server-relative path (the regex no longer
+    // accepts an absolute-URL prefix), so this is always anchored to the
+    // OLRC host — a foreign host can never become a uslmUrl.
+    const fullUrl = `${OLRC_BASE_URL}${path}`;
 
     results.push({
       title,
@@ -180,6 +210,11 @@ export class OlrcFetcher implements IUsCodeFetcher {
       return result;
     }
 
+    if (exceedsContentLengthLimit(result.value)) {
+      timer();
+      return err(new Error('Download exceeds size limit'));
+    }
+
     const html = await result.value.text();
     let points = parseReleasePoints(html);
     this.metrics.recordDiscovered(points.length);
@@ -209,13 +244,18 @@ export class OlrcFetcher implements IUsCodeFetcher {
       return priorResult;
     }
 
+    if (exceedsContentLengthLimit(priorResult.value)) {
+      timer();
+      return err(new Error('Download exceeds size limit'));
+    }
+
     const priorHtml = await priorResult.value.text();
     const historicalPoints = parsePriorReleasePoints(priorHtml);
     this.metrics.recordDiscovered(historicalPoints.length);
 
     // Also fetch current release point to include it
     const currentResult = await fetchWithRetry(OLRC_DOWNLOAD_PAGE, this.logger);
-    if (currentResult.ok) {
+    if (currentResult.ok && !exceedsContentLengthLimit(currentResult.value)) {
       const currentHtml = await currentResult.value.text();
       const current = parseCurrentRelease(currentHtml);
       if (current) {
@@ -257,7 +297,28 @@ export class OlrcFetcher implements IUsCodeFetcher {
       return result;
     }
 
+    // Size cap (primary guard): reject before reading the body if the server
+    // advertises a Content-Length over the limit, avoiding runner OOM.
+    if (exceedsContentLengthLimit(result.value)) {
+      const durationMs = performance.now() - startMs;
+      this.metrics.recordDuration(durationMs);
+      this.metrics.recordError('network');
+      timer();
+      return err(new Error('Download exceeds size limit'));
+    }
+
     const buffer = Buffer.from(await result.value.arrayBuffer());
+
+    // Defense-in-depth: catch oversized bodies that lacked a (truthful)
+    // Content-Length header.
+    if (buffer.length > MAX_DOWNLOAD_BYTES) {
+      const durationMs = performance.now() - startMs;
+      this.metrics.recordDuration(durationMs);
+      this.metrics.recordError('network');
+      timer();
+      return err(new Error('Download exceeds size limit'));
+    }
+
     const hash = sha256(buffer);
     const hashKey = `xml:${releasePoint.title}:${releasePoint.uslmUrl}`;
 


### PR DESCRIPTION
Closes #201 (security review findings).

## SSRF — restrict release-point links to the OLRC host
`parseReleasePoints`' link regex accepted an optional absolute-URL prefix:
```
/href="((?:https?:\/\/[^"/]+)?\/download\/releasepoints\/...
```
so an `href` to **any** host (on a compromised/MitM'd OLRC page) could become a `uslmUrl` that `fetchXml` then fetched verbatim — the only gate being a valid ZIP signature (attacker-suppliable). **Fix:** drop the absolute-URL alternative; the parser now matches only OLRC **server-relative** paths, so every `uslmUrl` is anchored to `https://uscode.house.gov`. The anti-ReDoS anchoring (`[^"/]`) is preserved.

## Response-size cap — avoid runner OOM
`fetchXml` read the body with no limit. **Fix:** add `MAX_DOWNLOAD_BYTES` (300 MiB — generous vs the ~100–150 MB all-titles archive) and `exceedsContentLengthLimit(response)`; a `Content-Length` over the cap returns an error Result up-front, with a post-read `buffer.length` backstop for missing/unparseable headers. Applied to the archive download and the release-point page reads.

## Tests
- foreign-host `href="https://evil.example/.../xml_usc18@1-1.zip"` never yields a `uslmUrl` containing `evil.example` (always OLRC-anchored).
- a mocked response with `Content-Length` over the cap yields an error Result.

Verification: `pnpm --filter @civic-source/fetcher test` → **127 passed**; `pnpm build` → **8/8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)