### PR TITLE
fix(types): constrain rendered/fetched URLs to http(s) (closes #210)

### DIFF
--- a/apps/web/src/content.config.ts
+++ b/apps/web/src/content.config.ts
@@ -27,7 +27,14 @@ const annotations = defineCollection({
       court: z.string(),
       date: z.string(),
       holdingSummary: z.string().optional(),
-      sourceUrl: z.string().optional(),
+      // Constrain to http(s) (or empty) so a malformed annotation can't inject
+      // a `javascript:`/`data:` URL that the precedent UI renders as an href (#210).
+      sourceUrl: z
+        .string()
+        .refine((u) => u === '' || /^https?:\/\//i.test(u), {
+          message: 'sourceUrl must use the http(s) scheme',
+        })
+        .optional(),
       impact: z.string().optional(),
     })).default([]),
   }),

--- a/packages/types/src/__tests__/schemas.test.ts
+++ b/packages/types/src/__tests__/schemas.test.ts
@@ -43,6 +43,11 @@ describe('ReleasePointSchema', () => {
     expect(() => ReleasePointSchema.parse({ ...valid, uslmUrl: 'not-a-url' })).toThrow();
   });
 
+  it('rejects non-http(s) uslmUrl schemes', () => {
+    expect(() => ReleasePointSchema.parse({ ...valid, uslmUrl: 'javascript:alert(1)' })).toThrow();
+    expect(() => ReleasePointSchema.parse({ ...valid, uslmUrl: 'ftp://uscode.house.gov/x.zip' })).toThrow();
+  });
+
   it('rejects wrong-length sha256Hash', () => {
     expect(() => ReleasePointSchema.parse({ ...valid, sha256Hash: 'abc' })).toThrow();
   });
@@ -90,6 +95,10 @@ describe('CaseAnnotationSchema', () => {
 
   it('rejects invalid court', () => {
     expect(() => CaseAnnotationSchema.parse({ ...valid, court: 'State' })).toThrow();
+  });
+
+  it('rejects a javascript: sourceUrl (would render as an href)', () => {
+    expect(() => CaseAnnotationSchema.parse({ ...valid, sourceUrl: 'javascript:alert(document.cookie)' })).toThrow();
   });
 
   it('rejects holdingSummary over 500 chars', () => {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -14,6 +14,18 @@ export function err<E>(error: E): Result<never, E> {
   return { ok: false, error };
 }
 
+// --- Shared field schemas ---
+
+/**
+ * A URL constrained to the http(s) scheme. Plain `z.url()` accepts dangerous
+ * schemes such as `javascript:` and `data:`; several of these values are later
+ * rendered as `href`s or used to download content, so we reject anything that
+ * is not http/https at the validation boundary (defense-in-depth — see #210).
+ */
+export const HttpUrlSchema = z
+  .url()
+  .refine((u) => /^https?:\/\//i.test(u), { message: 'URL must use the http(s) scheme' });
+
 // --- Release Point schema ---
 
 export const ReleasePointSchema = z.object({
@@ -24,7 +36,7 @@ export const ReleasePointSchema = z.object({
   /** Release date in ISO 8601 datetime format (ET timezone) */
   dateET: z.string().datetime(),
   /** URL to the USLM XML download for this release */
-  uslmUrl: z.url(),
+  uslmUrl: HttpUrlSchema,
   /** SHA-256 hex digest for integrity verification (64 hex characters) */
   sha256Hash: z.string().length(64),
 });
@@ -49,7 +61,7 @@ export const CaseAnnotationSchema = z.object({
   court: z.enum(["SCOTUS", "Appellate", "District"]),
   date: z.string(),
   holdingSummary: z.string().max(500),
-  sourceUrl: z.url(),
+  sourceUrl: HttpUrlSchema,
   impact: PrecedentImpactSchema,
   /** Public Law the statute was current through when this case was decided */
   statuteVersionRef: z.string().optional(),


### PR DESCRIPTION
Closes #210 (security hardening from the `packages/types` review).

## Problem
`z.url()` accepts dangerous schemes (`javascript:`, `data:`, `ftp:`). Two fields validated with it reach sensitive sinks:
- `CaseAnnotationSchema.sourceUrl` is rendered directly as an **href** — `PrecedentDrawer.svelte:93,145`, `statute/[...slug].astro:397` → a `javascript:` value is XSS-on-click.
- `ReleasePointSchema.uslmUrl` is used to **download** content in the fetcher.

The web content collection was even looser (`sourceUrl: z.string()`).

## Fix
- New exported `HttpUrlSchema = z.url().refine(http(s))` in `packages/types`, applied to `uslmUrl` and `sourceUrl`.
- `apps/web/src/content.config.ts`: `sourceUrl` tightened to http(s)-or-empty so malformed annotation data fails the content build loudly instead of rendering a bad href.

Low real-world likelihood today (URLs are constructed from `uscode.house.gov` / `courtlistener.com`), but the scheme was unenforced at the schema/render boundary — this closes it as defense-in-depth alongside #200/#207.

## Verification
- Confirmed `z.url()` accepts `javascript:` in this Zod version; the refined schema rejects `javascript:`/`ftp:`/garbage and accepts https.
- New tests reject `javascript:`/`ftp:` for `uslmUrl` and `javascript:` for `sourceUrl`.
- `pnpm --filter @civic-source/types test` (40), `fetcher` (123), `annotator` all pass; `pnpm build` 8/8. No fixture breakage (production URLs are https).

🤖 Generated with [Claude Code](https://claude.com/claude-code)