### PR TITLE
fix(web): sanitize rendered statute Markdown with rehype-sanitize (closes #200)

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -1,10 +1,18 @@
 import { defineConfig } from 'astro/config';
 import svelte from '@astrojs/svelte';
 import tailwindcss from '@tailwindcss/vite';
+import rehypeSanitize from 'rehype-sanitize';
 
 export default defineConfig({
   integrations: [svelte()],
   vite: { plugins: [tailwindcss()] },
   site: 'https://civic-source.github.io',
   base: '/us-code-tracker/',
+  // Sanitize the rendered statute Markdown (#200). Statute content derives
+  // from external OLRC XML; the default (GitHub) schema strips raw HTML
+  // (e.g. <img onerror>, <script>) and disallows non-http(s) link protocols
+  // (e.g. [x](javascript:...)), closing the stored-XSS surface at render time.
+  markdown: {
+    rehypePlugins: [rehypeSanitize],
+  },
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "@tailwindcss/vite": "^4.3.0",
     "astro": "^6.4.8",
     "pagefind": "^1.5.2",
+    "rehype-sanitize": "^6.0.0",
     "sanitize-html": "^2.17.4",
     "svelte": "^5.55.7",
     "tailwindcss": "^4.3.0"

--- a/apps/web/src/__tests__/markdown-sanitize.test.ts
+++ b/apps/web/src/__tests__/markdown-sanitize.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import rehypeSanitize from 'rehype-sanitize';
+import astroConfig from '../../astro.config.mjs';
+
+/**
+ * Guards the #200 render-side XSS mitigation: statute Markdown (derived from
+ * external OLRC XML) must be sanitized at render so embedded raw HTML
+ * (<img onerror>, <script>) and non-http(s) link protocols (javascript:) cannot
+ * become live. The realistic regression is the sanitizer being dropped from the
+ * Astro config, so assert it stays wired. (rehype-sanitize's own stripping
+ * behaviour is verified upstream and via the build-smoke documented in the PR.)
+ */
+describe('markdown sanitization wiring', () => {
+  it('astro config registers rehype-sanitize as a markdown rehype plugin', () => {
+    const plugins = astroConfig.markdown?.rehypePlugins ?? [];
+    expect(plugins).toContain(rehypeSanitize);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       pagefind:
         specifier: ^1.5.2
         version: 1.5.2
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       sanitize-html:
         specifier: ^2.17.4
         version: 2.17.4
@@ -1909,6 +1912,9 @@ packages:
   hast-util-raw@9.1.0:
     resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
 
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
@@ -2486,6 +2492,9 @@ packages:
 
   rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
@@ -4870,6 +4879,12 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.1
+      unist-util-position: 5.0.0
+
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.4
@@ -5586,6 +5601,11 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-raw: 9.1.0
       vfile: 6.0.3
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
 
   rehype-stringify@10.0.1:
     dependencies:


### PR DESCRIPTION
Closes #200 — the render-side / authoritative half of the statute-rendering XSS hardening (the source-side escape was #207; this completes it).

## Problem
Statute Markdown is rendered via `<Content />` with **no** sanitization, and its content derives from external OLRC XML. Embedded raw HTML (`<img onerror>`, `<script>`) or a `javascript:` link would render live — the H2 surface, plus the Markdown-link residual (`[x](javascript:…)`) the consensus review flagged on #207 that the source-side `<`/`>` escape couldn't cover.

## Fix
Add `rehype-sanitize` (default GitHub schema) to the Astro markdown pipeline in `astro.config.mjs`. It strips raw HTML and disallows non-http(s) link protocols at render time — the **complete** render-side control.

Safe for this site: `ArticleToc` assigns heading ids **client-side**, so sanitizing server-side ids doesn't affect the TOC; there was no prior markdown rehype/remark config to conflict with.

## Verification (faithful build-smoke + committed guard)
Built a temp statute fixture (then removed — not committed) through the real Astro build and inspected the output HTML:

| Input in statute body | Rendered output | Result |
|---|---|---|
| `<img src=x onerror=alert('X')>` | `<p>&#x3C;img src=x onerror=…></p>` (escaped text) | ✅ inert |
| `<script>alert('X')</script>` | removed | ✅ dropped |
| `[bad](javascript:alert('X'))` | href stripped | ✅ neutralized |
| `## Legit Heading` | `<h2>` | ✅ preserved |
| `[good](https://example.com)` | `<a href="https://example.com">` | ✅ preserved |

A committed test (`apps/web/src/__tests__/markdown-sanitize.test.ts`) asserts the sanitizer stays wired in the config (guards the realistic regression — config removal — without re-testing upstream's stripping).

`pnpm --filter @civic-source/web typecheck` 0 errors; `pnpm build` 8/8 (6 web+pkgs) green.

## Notes
This + #207 give layered defense (source-side escape + render-side sanitize). The remaining #200 item (M1 — CSP `'unsafe-inline'`) is tracked separately; with H1/H2 fixed at the source and render layers, the CSP is now defense-in-depth on top of closed vectors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)