### PR TITLE
fix(fetcher): parse redesigned OLRC download page (closes #216)

### DIFF
--- a/packages/fetcher/src/__tests__/fetcher.test.ts
+++ b/packages/fetcher/src/__tests__/fetcher.test.ts
@@ -138,6 +138,49 @@ describe('parseReleasePoints', () => {
     expect(parseReleasePoints('<html><body>Nothing here</body></html>')).toEqual([]);
   });
 
+  it('parses the redesigned OLRC page with relative releasepoints hrefs', () => {
+    // Trimmed fixture extracted verbatim from the live OLRC download.shtml
+    // (Public Law 119-99). Links are now RELATIVE: no leading slash and no
+    // `/download/` prefix. The xml_uscAll link must be skipped.
+    const html = `
+      <h2>Current Release Point</h2>
+      <h3 class="releasepointinformation">Public Law 119-99 (06/12/2026)</h3>
+      <div class="itemdownloadlinks">
+        <a href="releasepoints/us/pl/119/99/xml_uscAll@119-99.zip" title="All USC Titles in XML">[XML]</a>
+      </div>
+      <div class="itemdownloadlinks">
+        <a href="releasepoints/us/pl/119/99/xml_usc01@119-99.zip" title="Title 1 XML">[XML]</a>
+      </div>
+      <div class="itemdownloadlinks">
+        <a href="releasepoints/us/pl/119/99/xml_usc05a@119-99.zip" title="Title 5 App. XML">[XML]</a>
+      </div>
+      <div class="itemdownloadlinks">
+        <a href="releasepoints/us/pl/119/99/xml_usc18@119-99.zip" title="Title 18 XML">[XML]</a>
+      </div>
+      <div class="itemdownloadlinks">
+        <a href="releasepoints/us/pl/119/99/xml_usc42@119-99.zip" title="Title 42 XML">[XML]</a>
+      </div>
+    `;
+    const points = parseReleasePoints(html);
+
+    // One entry per title; xml_uscAll skipped.
+    // The live page emits zero-padded title tokens (xml_usc01, xml_usc05a),
+    // so the captured title preserves that padding.
+    expect(points).toHaveLength(4);
+    expect(points.map((p) => p.title)).toEqual(['01', '05a', '18', '42']);
+
+    for (const p of points) {
+      expect(p.publicLaw).toBe('PL 119-99');
+      expect(p.uslmUrl.startsWith('https://uscode.house.gov/download/releasepoints/')).toBe(true);
+    }
+
+    const byTitle = new Map(points.map((p) => [p.title, p]));
+    expect(byTitle.get('01')?.uslmUrl).toContain('xml_usc01@119-99.zip');
+    expect(byTitle.get('05a')?.uslmUrl).toContain('xml_usc05a@119-99.zip');
+    expect(byTitle.get('18')?.uslmUrl).toContain('xml_usc18@119-99.zip');
+    expect(byTitle.get('42')?.uslmUrl).toContain('xml_usc42@119-99.zip');
+  });
+
   it('handles titles with letter suffixes (e.g., 5a)', () => {
     const html = `
       <h2>Public Law 118-200 (11/15/2024)</h2>

--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -2,10 +2,10 @@ import { createHash } from 'node:crypto';
 import { type IUsCodeFetcher, type ReleasePoint, type Result, ok, err } from '@civic-source/types';
 import { type Logger, createLogger, fetchWithRetry as sharedFetchWithRetry } from '@civic-source/shared';
 import {
-  OLRC_BASE_URL,
   OLRC_DOWNLOAD_PAGE,
   OLRC_PRIOR_RELEASE_POINTS_PAGE,
   MAX_DOWNLOAD_BYTES,
+  titleXmlUrl,
 } from './constants.js';
 import { HashStore } from './hash-store.js';
 import { FetcherMetrics } from './metrics.js';
@@ -139,17 +139,28 @@ export function parseReleasePoints(html: string): ReleasePoint[] {
   const results: ReleasePoint[] = [];
   const currentRelease = parseCurrentRelease(html);
 
-  // Match links like: /download/releasepoints/us/pl/118/42/xml_usc42@118-200.zip
+  // Match links like:
+  //   releasepoints/us/pl/119/99/xml_usc01@119-99.zip        (relative — live OLRC)
+  //   download/releasepoints/us/pl/118/42/xml_usc42@118-200.zip
+  //   /download/releasepoints/us/pl/118/42/xml_usc42@118-200.zip
   //
-  // SSRF hardening: only accept OLRC server-relative hrefs (the form the OLRC
-  // pages actually emit). We deliberately do NOT accept an absolute-URL prefix
-  // here: allowing one would let an href to an arbitrary host become a
-  // uslmUrl that fetchXml then fetches verbatim. Because every match is a bare
-  // path, fullUrl below is always anchored to the OLRC host.
+  // The `/download/` (and leading slash) prefix is OPTIONAL: the redesigned
+  // OLRC download page emits bare relative hrefs (no leading slash, no
+  // `/download/`). We capture the congress and law path segments and
+  // reconstruct the uslmUrl canonically via titleXmlUrl below.
+  //
+  // SSRF hardening (#205): we never echo the matched href into the uslmUrl.
+  // The regex anchors on `href="` immediately followed by an optional
+  // `download/` and then `releasepoints/us/pl/...`, so an absolute foreign
+  // href such as `href="https://evil.example/download/releasepoints/..."`
+  // never matches (the `https:` between `href="` and `download/` breaks it).
+  // Every uslmUrl is rebuilt from titleXmlUrl, so it is always OLRC-anchored.
   //
   // Anchor segments to non-slash/non-quote chars so we don't get polynomial
-  // backtracking on malformed input (CodeQL js/polynomial-redos).
-  const linkPattern = /href="(\/download\/releasepoints\/us\/pl\/(\d+)\/([^/"]+)\/xml_usc[^"/]+\.zip)"/g;
+  // backtracking on malformed input (CodeQL js/polynomial-redos). The optional
+  // prefix is a fixed alternation, not an unbounded `[^"]*` run.
+  const linkPattern =
+    /href="(?:\/?download\/)?releasepoints\/us\/pl\/(\d+)\/([^/"]+)\/xml_usc[^"/]+\.zip"/g;
   let match: RegExpExecArray | null;
 
   // Extract unique title numbers from XML download links
@@ -157,20 +168,21 @@ export function parseReleasePoints(html: string): ReleasePoint[] {
   const seen = new Set<string>();
 
   while ((match = linkPattern.exec(html)) !== null) {
-    const path = match[1];
-    if (!path) continue;
+    const congress = match[1];
+    const law = match[2];
+    if (!congress || !law) continue;
 
-    const titleMatch = titlePattern.exec(path);
+    const titleMatch = titlePattern.exec(match[0]);
     if (!titleMatch) continue;
 
     const title = titleMatch[1];
     if (!title || seen.has(title)) continue;
     seen.add(title);
 
-    // path is always an OLRC server-relative path (the regex no longer
-    // accepts an absolute-URL prefix), so this is always anchored to the
-    // OLRC host — a foreign host can never become a uslmUrl.
-    const fullUrl = `${OLRC_BASE_URL}${path}`;
+    // Reconstruct the URL canonically so it is always anchored to the OLRC
+    // host regardless of whether the href was relative or absolute — a
+    // foreign host can never become a uslmUrl (#205 SSRF protection).
+    const fullUrl = titleXmlUrl(congress, law, title);
 
     results.push({
       title,


### PR DESCRIPTION
Closes #216 — the critical bug found by validating the sync end-to-end.

## Problem
OLRC redesigned `download.shtml`. Per-title XML zip links are now **relative** hrefs (`releasepoints/us/pl/119/99/xml_usc01@119-99.zip` — no leading slash, no `/download/`). `parseReleasePoints` required `/download/releasepoints/`, so it matched **0** links → `listReleasePoints()` returned `[]` → the weekly sync ran (after #194/#204) but silently produced nothing. CI missed it because the fixtures still used the old markup.

## Fix
- `linkPattern`: make the `/download/` (and leading slash) prefix **optional**, capture congress + law. Anti-ReDoS anchoring preserved (fixed alternation, `[^/"]` segments — no unbounded `[^"]*`).
- Reconstruct `uslmUrl` via `titleXmlUrl(congress, law, title)` instead of echoing the matched href → every URL is OLRC-anchored, **preserving the #205 SSRF protection** for relative *and* absolute hrefs (a foreign `href="https://evil/..."` still can't match: `https:` sits between `href="` and `download/`).
- `parseCurrentRelease` already matched the new `<h3 class="releasepointinformation">Public Law 119-99 (06/12/2026)</h3>` header — unchanged.

## Verification
- **Against the real live page:** the fixed parser extracts **all 59 titles** for `PL 119-99`, every `uslmUrl` `https://uscode.house.gov/download/releasepoints/...`, `uscAll` skipped.
- New test uses a trimmed fixture of the **real** current markup.
- Existing `parseReleasePoints` tests (SSRF, ReDoS, `5a` suffix, dedup, empty fallback) unaffected. `pnpm --filter @civic-source/fetcher test` → **132**; `pnpm build` 6/6.

## ⚠️ Final validation needs owner approval
A live `workflow_dispatch` of the sync will now find 59 titles and **fetch+transform all ~53K sections, then commit+push them to `civic-source/us-code`** — a large, real data operation. Recommend doing that deliberately (once) after merge, not automatically. Happy to trigger it on your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)