### PR TITLE
docs: refresh stale Astro/Zod version references (post Astro 7)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,7 +37,7 @@ OLRC Website (uscode.house.gov)
 | `@civic-source/fetcher` | `packages/fetcher` | Downloads release point listings and ZIP archives from the OLRC. Includes SHA-256 hash-based caching (`HashStore`) to skip unchanged content, exponential backoff retry, and a structured logger. |
 | `@civic-source/transformer` | `packages/transformer` | Parses USLM XML using `fast-xml-parser` in `preserveOrder` mode and generates per-section Markdown files with YAML frontmatter. Handles namespace-aware element traversal. |
 | `@civic-source/annotator` | `packages/annotator` | Queries CourtListener's full-text search API to find cases citing a given statute section. Maps results to the `PrecedentAnnotation` schema. Rate-limited. |
-| `@civic-source/web` | `apps/web` | Astro v5 static site that renders statute Markdown with Tailwind CSS styling, Pagefind search, and Svelte interactive components. |
+| `@civic-source/web` | `apps/web` | Astro v7 static site that renders statute Markdown with Tailwind CSS styling, Pagefind search, and Svelte interactive components. |
 
 ## Dual-Repo Strategy
 
@@ -88,7 +88,7 @@ This pattern was chosen because:
 |--------|----------------------|-----------|
 | **fast-xml-parser** | Cheerio | Namespace-aware parsing required for USLM XML. Built-in XXE prevention. See `docs/SPEC_DEVIATIONS.md`. |
 | **Zod** | io-ts, manual validation | Runtime schema validation with TypeScript type inference. Single schema definition serves both validation and type generation. |
-| **Astro v5** | Next.js, plain HTML | Static-first with zero JS by default. Content-heavy site does not need a SPA framework. Svelte islands for interactive components. |
+| **Astro v7** | Next.js, plain HTML | Static-first with zero JS by default. Content-heavy site does not need a SPA framework. Svelte islands for interactive components. |
 | **Tailwind CSS v4** | v3, plain CSS | Greenfield project; v4 is actively developed while v3 is in maintenance. Vite-native plugin simplifies build. |
 | **Turborepo** | Nx, Lerna | Lightweight build orchestration for pnpm workspaces. Task caching and topological dependency ordering out of the box. |
 | **Result\<T,E\>** | Exceptions | Explicit error handling via discriminated unions. Callers must handle both success and failure paths. No uncaught exception surprises. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@
 
 - **Monorepo:** Turborepo + pnpm workspaces
 - **Language:** TypeScript 6.0+ (strict mode, NodeNext)
-- **Validation:** Zod v3
+- **Validation:** Zod v4
 - **Testing:** Vitest
-- **Web:** Astro v5
+- **Web:** Astro v7
 - **CI:** GitHub Actions (ubuntu-latest, Node 24)
 
 ## Quick Commands

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Automated pipeline that fetches U.S. Code XML releases from the Office of the La
 | `@civic-source/transformer` | USLM XML to Markdown converter with status detection |
 | `@civic-source/annotator` | CourtListener precedent annotation generator |
 | `@civic-source/shared` | Shared utilities (logger, retry, token bucket) |
-| `@civic-source/web` | Astro 6 static site with Svelte components |
+| `@civic-source/web` | Astro 7 static site with Svelte components |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ npx tsx scripts/generate-diffs.ts --repo /path/to/us-code --output apps/web/publ
 
 | Dependency | Version | Purpose |
 |------------|---------|---------|
-| Astro | 6.x | Static site generator |
+| Astro | 7.x | Static site generator |
 | Svelte | 5.x | Interactive components |
 | Zod | 4.x | Schema validation |
 | Tailwind CSS | 4.x | Styling |


### PR DESCRIPTION
Post-upgrade doc hygiene after #218 (Astro 7). The docs still referenced older versions:

- **CLAUDE.md** — "Astro v5" → **v7**; "Zod v3" → **v4** (the project is on `zod ^4.4.3`, so v3 was long stale).
- **README.md** — web package row "Astro 6" → **Astro 7**.
- **ARCHITECTURE.md** — web package row and the technology-choices row "Astro v5" → **v7**.

Docs-only, no code change. Verified no remaining `Astro v5/6` or `Zod v3` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)