### PR TITLE
fix(transformer): escape YAML frontmatter strings (closes #221)

### DIFF
--- a/packages/transformer/src/__tests__/transformer.test.ts
+++ b/packages/transformer/src/__tests__/transformer.test.ts
@@ -235,6 +235,21 @@ describe('generateFrontmatter', () => {
     expect(readScalar(fm, 'title')).toBe(title);
   });
 
+  it('escapes raw control characters so the scalar stays parseable', () => {
+    const title = ['Section 5', String.fromCharCode(0), 'NUL', String.fromCharCode(0x1b), 'ESC'].join(' ');
+    const fm = generateFrontmatter({
+      title,
+      usc_title: 5,
+      usc_section: '5',
+      chapter: 1,
+      current_through: 'PL 119-73',
+      classification: '5 U.S.C. § 5',
+      generated_at: '2026-03-28T14:00:00-04:00',
+      status: 'active',
+    });
+    expect(readScalar(fm, 'title')).toBe(title);
+  });
+
   it('escapes quotes/backslashes across all string fields', () => {
     const fm = generateFrontmatter({
       title: 'has "quote"',

--- a/packages/transformer/src/__tests__/transformer.test.ts
+++ b/packages/transformer/src/__tests__/transformer.test.ts
@@ -191,6 +191,66 @@ describe('generateFrontmatter', () => {
     expect(fm).toContain('classification: "26 U.S.C.');
     expect(fm).toContain('status: "active"');
   });
+
+  /**
+   * Extract the double-quoted scalar that follows `key: ` and decode it. YAML
+   * double-quoted escaping for `"`, `\`, and the `\n`/`\r`/`\t` control escapes
+   * is a subset of JSON string syntax, so JSON.parse round-trips the value and
+   * also fails loudly if the scalar is malformed (i.e. unescaped).
+   */
+  function readScalar(fm: string, key: string): string {
+    const line = fm.split('\n').find((l) => l.startsWith(`${key}: "`));
+    if (line === undefined) throw new Error(`no quoted scalar for ${key}`);
+    return JSON.parse(line.slice(key.length + 2)) as string;
+  }
+
+  it('escapes double quotes in the title so the frontmatter stays valid', () => {
+    // Real U.S. Code content: defined terms are quoted in headings.
+    const title = 'Section 5 - Definition of "employee" rules';
+    const fm = generateFrontmatter({
+      title,
+      usc_title: 5,
+      usc_section: '5',
+      chapter: 1,
+      current_through: 'PL 119-73',
+      classification: '5 U.S.C. § 5',
+      generated_at: '2026-03-28T14:00:00-04:00',
+      status: 'active',
+    });
+    expect(readScalar(fm, 'title')).toBe(title);
+  });
+
+  it('escapes a trailing backslash so it does not escape the closing quote', () => {
+    const title = 'Section 5 - path C:\\';
+    const fm = generateFrontmatter({
+      title,
+      usc_title: 5,
+      usc_section: '5',
+      chapter: 1,
+      current_through: 'PL 119-73',
+      classification: '5 U.S.C. § 5',
+      generated_at: '2026-03-28T14:00:00-04:00',
+      status: 'active',
+    });
+    expect(readScalar(fm, 'title')).toBe(title);
+  });
+
+  it('escapes quotes/backslashes across all string fields', () => {
+    const fm = generateFrontmatter({
+      title: 'has "quote"',
+      usc_title: 5,
+      usc_section: '5"a',
+      chapter: 1,
+      current_through: 'PL "119"-73',
+      classification: 'C:\\ "x"',
+      generated_at: '2026-03-28T14:00:00-04:00',
+      status: 'active',
+    });
+    expect(readScalar(fm, 'title')).toBe('has "quote"');
+    expect(readScalar(fm, 'usc_section')).toBe('5"a');
+    expect(readScalar(fm, 'current_through')).toBe('PL "119"-73');
+    expect(readScalar(fm, 'classification')).toBe('C:\\ "x"');
+  });
 });
 
 describe('FrontmatterSchema', () => {

--- a/packages/transformer/src/markdown-generator.ts
+++ b/packages/transformer/src/markdown-generator.ts
@@ -146,18 +146,37 @@ export function buildSectionPath(titleNum: string, chapterNum: string, sectionNu
   return `statutes/title-${titleNum}/chapter-${chapterNum}/section-${sectionNum}.md`;
 }
 
+/**
+ * Serialize a string as a YAML double-quoted scalar.
+ *
+ * Statute headings carry untrusted OLRC content (e.g. defined terms quoted as
+ * `"employee"`); interpolating them raw into `title: "..."` produces invalid
+ * YAML and is a frontmatter-injection vector. Escape per the YAML double-quoted
+ * rules: backslash first, then the quote, then the whitespace control chars
+ * that `extractTextFromNodes` collapses but public callers may still pass.
+ */
+function yamlQuote(value: string): string {
+  const escaped = value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+  return `"${escaped}"`;
+}
+
 /** Generate YAML frontmatter string from validated data */
 export function generateFrontmatter(data: Frontmatter): string {
   const lines = [
     '---',
-    `title: "${data.title}"`,
+    `title: ${yamlQuote(data.title)}`,
     `usc_title: ${data.usc_title}`,
-    `usc_section: "${data.usc_section}"`,
+    `usc_section: ${yamlQuote(data.usc_section)}`,
     `chapter: ${data.chapter}`,
-    `current_through: "${data.current_through}"`,
-    `classification: "${data.classification}"`,
-    `generated_at: "${data.generated_at}"`,
-    `status: "${data.status}"`,
+    `current_through: ${yamlQuote(data.current_through)}`,
+    `classification: ${yamlQuote(data.classification)}`,
+    `generated_at: ${yamlQuote(data.generated_at)}`,
+    `status: ${yamlQuote(data.status)}`,
     '---',
     '',
   ];

--- a/packages/transformer/src/markdown-generator.ts
+++ b/packages/transformer/src/markdown-generator.ts
@@ -161,7 +161,13 @@ function yamlQuote(value: string): string {
     .replace(/"/g, '\\"')
     .replace(/\n/g, '\\n')
     .replace(/\r/g, '\\r')
-    .replace(/\t/g, '\\t');
+    .replace(/\t/g, '\\t')
+    // Remaining C0/DEL control chars are invalid raw inside a YAML
+    // double-quoted scalar; emit \uXXXX so the scalar stays parseable.
+    // eslint-disable-next-line no-control-regex -- intentionally matching control chars to escape them
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, (c) =>
+      `\\u${c.charCodeAt(0).toString(16).padStart(4, '0')}`
+    );
   return `"${escaped}"`;
 }
 


### PR DESCRIPTION
Closes #221.

## Summary

`generateFrontmatter` (`markdown-generator.ts`) interpolated every string field raw into `key: "..."`. `extractTextFromNodes` escapes only `<`/`>`, never `"` or `\`, so a section `<heading>` containing a double-quote — **common real U.S. Code content** (defined terms like `"employee"`) — produced **invalid YAML**, breaking the page build / metadata, and was a frontmatter-key **injection** vector.

Render-side `rehype-sanitize` (#200) does **not** cover this: frontmatter is parsed as *data*, never rendered as HTML.

## Fix

Add a `yamlQuote()` helper that escapes per YAML double-quoted rules (`\` → `\\`, then `"` → `\"`, then `\n`/`\r`/`\t`) and route all string fields through it. Numeric fields (`usc_title`, `chapter`) are bare and unaffected.

## Testing

- **+3 tests**: embedded double-quote, trailing backslash, and all-string-fields — each **round-trips** the emitted scalar back to the original (decode shares escaping semantics with YAML double-quoted scalars, and fails loudly on a malformed/unescaped scalar). The pre-existing clean-input test still passes.
- `pnpm --filter @civic-source/transformer test` → **74 passed**.
- typecheck / lint / build clean.

## Scope

Independent of #220 (fetcher) — different package, no overlap. Not a duplicate of #207 (`<`/`>` body escaping) or #200 (JSON-LD/body render-side control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)