### PR TITLE
fix(annotator): escape all string fields in sidecar YAML serialization

### DIFF
--- a/packages/annotator/src/__tests__/annotator.test.ts
+++ b/packages/annotator/src/__tests__/annotator.test.ts
@@ -373,6 +373,70 @@ describe('annotationToYaml', () => {
     expect(yaml).toContain('caseName: "X \\\\ Y"');
     expect(yaml).toContain('holdingSummary: "path: C:\\\\Users\\\\test"');
   });
+
+  /**
+   * Extract the double-quoted scalar after `key: ` (allowing leading indent)
+   * and decode it. YAML double-quoted escaping for `"`, `\`, `\n/\r/\t`, and
+   * `\uXXXX` is a subset of JSON string syntax, so JSON.parse round-trips the
+   * value and fails loudly on a malformed (unescaped) scalar.
+   */
+  function readScalar(yaml: string, key: string): string {
+    const line = yaml.split('\n').find((l) => l.trimStart().startsWith(`${key}: "`));
+    if (line === undefined) throw new Error(`no quoted scalar for ${key}`);
+    const trimmed = line.trimStart();
+    return JSON.parse(trimmed.slice(key.length + 2)) as string;
+  }
+
+  it('escapes a sourceUrl that injects a quote+newline (forged key)', () => {
+    // absolute_url is untrusted CourtListener data; a crafted value must not be
+    // able to close the scalar and inject a sibling key into the sidecar.
+    const sourceUrl = 'https://www.courtlistener.com/op/1/"\n    impact: "unconstitutional';
+    const yaml = annotationToYaml({
+      targetSection: '18 U.S.C. 111',
+      lastSyncedET: '2025-06-15T12:00:00.000Z',
+      cases: [{
+        caseName: 'A v. B',
+        citation: '',
+        court: 'District',
+        date: '2024-01-01',
+        holdingSummary: '',
+        sourceUrl,
+        impact: 'interpretation',
+      }],
+    });
+    expect(readScalar(yaml, 'sourceUrl')).toBe(sourceUrl);
+    // The injected line must NOT appear as a real YAML key.
+    expect(yaml).not.toMatch(/^ {4}impact: "unconstitutional/m);
+  });
+
+  it('escapes an untrusted date field containing a quote', () => {
+    // result.dateFiled is only z.string()-validated — it accepts quotes.
+    const date = '2024-01-01" forged: "x';
+    const yaml = annotationToYaml({
+      targetSection: '18 U.S.C. 111',
+      lastSyncedET: '2025-06-15T12:00:00.000Z',
+      cases: [{
+        caseName: 'A v. B',
+        citation: '',
+        court: 'District',
+        date,
+        holdingSummary: '',
+        sourceUrl: 'https://example.com',
+        impact: 'interpretation',
+      }],
+    });
+    expect(readScalar(yaml, 'date')).toBe(date);
+  });
+
+  it('escapes an untrusted targetSection containing a quote', () => {
+    const targetSection = '18 U.S.C. 111" forged: "x';
+    const yaml = annotationToYaml({
+      targetSection,
+      lastSyncedET: '2025-06-15T12:00:00.000Z',
+      cases: [],
+    });
+    expect(readScalar(yaml, 'targetSection')).toBe(targetSection);
+  });
 });
 
 describe('getApiToken', () => {

--- a/packages/annotator/src/annotator.ts
+++ b/packages/annotator/src/annotator.ts
@@ -54,25 +54,42 @@ export function buildAnnotationPath(section: string): string {
   return `annotations/title-${titleNum}/section-${sectionNum}.yaml`;
 }
 
-/** Escape backslashes and double quotes for YAML double-quoted scalar. */
+/**
+ * Escape a string for a YAML double-quoted scalar.
+ *
+ * Case fields (caseName, snippet/holdingSummary, dateFiled, absolute_url ->
+ * sourceUrl) are untrusted CourtListener API data. Escape backslash first,
+ * then the quote, then the whitespace/control chars that would otherwise
+ * terminate or inject into the scalar — a `"` or newline in any field must not
+ * be able to forge or corrupt sidecar keys.
+ */
 function yamlEscape(s: string): string {
-  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t')
+    // eslint-disable-next-line no-control-regex -- intentionally matching control chars to escape them
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, (c) =>
+      `\\u${c.charCodeAt(0).toString(16).padStart(4, '0')}`
+    );
 }
 
 /** Serialize a PrecedentAnnotation to simple YAML (no external deps) */
 export function annotationToYaml(annotation: PrecedentAnnotation): string {
   const lines: string[] = [];
-  lines.push(`targetSection: "${annotation.targetSection}"`);
-  lines.push(`lastSyncedET: "${annotation.lastSyncedET}"`);
+  lines.push(`targetSection: "${yamlEscape(annotation.targetSection)}"`);
+  lines.push(`lastSyncedET: "${yamlEscape(annotation.lastSyncedET)}"`);
   lines.push('cases:');
   for (const c of annotation.cases) {
     lines.push(`  - caseName: "${yamlEscape(c.caseName)}"`);
     lines.push(`    citation: "${yamlEscape(c.citation)}"`);
-    lines.push(`    court: "${c.court}"`);
-    lines.push(`    date: "${c.date}"`);
+    lines.push(`    court: "${yamlEscape(c.court)}"`);
+    lines.push(`    date: "${yamlEscape(c.date)}"`);
     lines.push(`    holdingSummary: "${yamlEscape(c.holdingSummary)}"`);
-    lines.push(`    sourceUrl: "${c.sourceUrl}"`);
-    lines.push(`    impact: "${c.impact}"`);
+    lines.push(`    sourceUrl: "${yamlEscape(c.sourceUrl)}"`);
+    lines.push(`    impact: "${yamlEscape(c.impact)}"`);
   }
   return lines.join('\n') + '\n';
 }


### PR DESCRIPTION
## Summary

`annotationToYaml` (`packages/annotator/src/annotator.ts`) escaped only `caseName`/`citation`/`holdingSummary`. `sourceUrl`, `date`, `court`, `targetSection`, and `lastSyncedET` were interpolated **raw** into `key: "..."`.

Two of those carry attacker-influenced CourtListener API data:
- **`sourceUrl`** — built from the untrusted `absolute_url`.
- **`date`** — from `result.dateFiled`, validated only by `z.string()` (accepts `"`/newlines).

So a value containing a quote or newline could close the YAML scalar and **forge or corrupt sibling keys** in the annotation sidecar — a YAML-injection vector in the same class as #221/#222, in the annotator. (`date` is reachable regardless of any `z.url()` behavior since it has no URL validation.)

## Fix

Route every string field through `yamlEscape`, and strengthen `yamlEscape` to handle newlines, tabs, and C0/DEL control chars (it previously escaped only `\` and `"`). `court` is enum-bounded and `impact` is a literal, but escaping them too keeps the serializer uniformly safe rather than relying on per-field reasoning.

## Testing

- **+3 tests**: a `sourceUrl` injecting `"` + newline + a forged `impact:` key (asserts the forged line is **not** a real YAML key), a quote in `date`, and a quote in `targetSection` — each **round-trips** the emitted scalar back to the original.
- `pnpm --filter @civic-source/annotator test` → **88 passed**.
- typecheck / lint / build clean.

## Scope

Tightly scoped to the HIGH-severity escaping bug. Three lower-severity hardening gaps from the same review (host-pinning on `absolute_url`, adopting the shared retry, response size cap) are tracked separately in #223. Independent of #220 (fetcher) and #221/#222 (transformer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)