### PR TITLE
fix(annotator): pin sourceUrl to CourtListener origin (#223, finding 1)

### DIFF
--- a/packages/annotator/src/__tests__/annotator.test.ts
+++ b/packages/annotator/src/__tests__/annotator.test.ts
@@ -423,6 +423,13 @@ describe('courtListenerSourceUrl', () => {
     expect(new URL(out).origin).toBe('https://www.courtlistener.com');
   });
 
+  it('rejects a same-origin URL carrying attacker-controlled userinfo', () => {
+    // origin is www.courtlistener.com, but the rendered href embeds `evil.example@`.
+    expect(
+      courtListenerSourceUrl('https://evil.example@www.courtlistener.com/opinion/123/')
+    ).toBe('');
+  });
+
   it('returns empty string for an unparseable value', () => {
     expect(courtListenerSourceUrl('http://[::bad')).toBe('');
   });

--- a/packages/annotator/src/__tests__/annotator.test.ts
+++ b/packages/annotator/src/__tests__/annotator.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PrecedentAnnotationSchema } from '@civic-source/types';
 import { createLogger } from '@civic-source/shared';
-import { Annotator, mapCourt, buildAnnotationPath, annotationToYaml } from '../annotator.js';
+import { Annotator, mapCourt, buildAnnotationPath, annotationToYaml, courtListenerSourceUrl } from '../annotator.js';
 import { CourtListenerClient, type CourtListenerResult } from '../client.js';
 
 /** Build a fake CourtListener result */
@@ -396,5 +396,34 @@ describe('getApiToken', () => {
     delete process.env['COURTLISTENER_API_TOKEN'];
     const { getApiToken } = await import('../constants.js');
     expect(() => getApiToken()).toThrow();
+  });
+});
+
+describe('courtListenerSourceUrl', () => {
+  it('returns the resolved URL for a normal relative path', () => {
+    expect(courtListenerSourceUrl('/opinion/12345/doe-v-us/')).toBe(
+      'https://www.courtlistener.com/opinion/12345/doe-v-us/'
+    );
+  });
+
+  it('rejects an off-origin absolute URL', () => {
+    expect(courtListenerSourceUrl('https://evil.com/x')).toBe('');
+  });
+
+  it('rejects a protocol-relative URL that points off-site', () => {
+    expect(courtListenerSourceUrl('//evil.com/x')).toBe('');
+  });
+
+  it('does not let an @-authority trick redirect off-origin', () => {
+    // String concat would have made `https://www.courtlistener.com@evil.com/x`
+    // (authority evil.com); resolving as a relative ref keeps it same-origin.
+    const out = courtListenerSourceUrl('@evil.com/x');
+    expect(out.startsWith('https://www.courtlistener.com/')).toBe(true);
+    expect(out).not.toContain('evil.com/x"');
+    expect(new URL(out).origin).toBe('https://www.courtlistener.com');
+  });
+
+  it('returns empty string for an unparseable value', () => {
+    expect(courtListenerSourceUrl('http://[::bad')).toBe('');
   });
 });

--- a/packages/annotator/src/annotator.ts
+++ b/packages/annotator/src/annotator.ts
@@ -55,7 +55,18 @@ const COURTLISTENER_ORIGIN = new URL(COURTLISTENER_BASE_URL).origin;
 export function courtListenerSourceUrl(absoluteUrl: string): string {
   try {
     const resolved = new URL(absoluteUrl, `${COURTLISTENER_ORIGIN}/`);
-    return resolved.origin === COURTLISTENER_ORIGIN ? resolved.toString() : '';
+    // Pin the origin AND reject userinfo: a same-origin URL can still carry an
+    // attacker-controlled `user@` prefix (e.g.
+    // `https://evil.example@www.courtlistener.com/...`) whose origin matches but
+    // whose rendered href is misleading. Legitimate opinion paths never have it.
+    if (
+      resolved.origin !== COURTLISTENER_ORIGIN ||
+      resolved.username !== '' ||
+      resolved.password !== ''
+    ) {
+      return '';
+    }
+    return resolved.toString();
   } catch {
     return '';
   }

--- a/packages/annotator/src/annotator.ts
+++ b/packages/annotator/src/annotator.ts
@@ -1,7 +1,7 @@
 import { type PrecedentAnnotation, PrecedentAnnotationSchema, type Result, ok, err } from '@civic-source/types';
 import { type Logger, createLogger, TokenBucket } from '@civic-source/shared';
 import { type CourtListenerResult, CourtListenerClient } from './client.js';
-import { COURT_PRIORITY, MAX_HOLDING_SUMMARY_LENGTH, RATE_LIMIT_PER_HOUR, getApiToken } from './constants.js';
+import { COURTLISTENER_BASE_URL, COURT_PRIORITY, MAX_HOLDING_SUMMARY_LENGTH, RATE_LIMIT_PER_HOUR, getApiToken } from './constants.js';
 import { deduplicateCases } from './citation-utils.js';
 
 /** Result of annotating a section, including the output path */
@@ -36,6 +36,29 @@ function sortByCourtPriority(results: CourtListenerResult[]): CourtListenerResul
 function truncateSnippet(snippet: string): string {
   if (snippet.length <= MAX_HOLDING_SUMMARY_LENGTH) return snippet;
   return snippet.slice(0, MAX_HOLDING_SUMMARY_LENGTH - 3) + '...';
+}
+
+/** Origin of the CourtListener site — a sourceUrl must resolve to this host. */
+const COURTLISTENER_ORIGIN = new URL(COURTLISTENER_BASE_URL).origin;
+
+/**
+ * Resolve an untrusted CourtListener `absolute_url` into a same-origin source URL.
+ *
+ * `absolute_url` is API data; string-concatenating it onto the base host lets a
+ * poisoned value point the link off-site — `@evil.com/x` →
+ * `https://www.courtlistener.com@evil.com/x` (authority `evil.com`),
+ * `//evil.com/x`, or an outright `https://evil.com/x`. Resolving it as a
+ * relative reference and pinning the origin neutralizes all three: anything
+ * that does not resolve to the CourtListener origin collapses to `''` (an
+ * empty, schema-valid sourceUrl that renders no off-site href).
+ */
+export function courtListenerSourceUrl(absoluteUrl: string): string {
+  try {
+    const resolved = new URL(absoluteUrl, `${COURTLISTENER_ORIGIN}/`);
+    return resolved.origin === COURTLISTENER_ORIGIN ? resolved.toString() : '';
+  } catch {
+    return '';
+  }
 }
 
 /**
@@ -128,7 +151,7 @@ export class Annotator {
       court: mapCourt(result.court),
       date: result.dateFiled,
       holdingSummary: truncateSnippet(result.snippet),
-      sourceUrl: `https://www.courtlistener.com${result.absolute_url}`,
+      sourceUrl: courtListenerSourceUrl(result.absolute_url),
       impact: 'interpretation' as const,
     }));
 

--- a/packages/annotator/src/index.ts
+++ b/packages/annotator/src/index.ts
@@ -12,6 +12,6 @@ export {
 export { TIMEZONE, MAX_RETRIES, BASE_BACKOFF_MS } from '@civic-source/shared';
 
 export { CourtListenerClient, type CourtListenerResult } from './client.js';
-export { Annotator, mapCourt, buildAnnotationPath, annotationToYaml, type AnnotationResult } from './annotator.js';
+export { Annotator, mapCourt, buildAnnotationPath, annotationToYaml, courtListenerSourceUrl, type AnnotationResult } from './annotator.js';
 export { normalizeCitation, deduplicateCases } from './citation-utils.js';
 export { createLogger, type Logger, type LogLevel } from '@civic-source/shared';


### PR DESCRIPTION
Addresses **finding 1 of #223**.

## Summary

`sourceUrl` was built by string-concatenating the untrusted API `absolute_url` onto the base host:

```ts
sourceUrl: `https://www.courtlistener.com${result.absolute_url}`
```

A poisoned `absolute_url` could point the published link off-site **and still pass `HttpUrlSchema`** (which only checks the http(s) scheme, not the host):
- `@evil.com/x` → `https://www.courtlistener.com@evil.com/x` (authority `evil.com`)
- `//evil.com/x` (protocol-relative)
- `https://evil.com/x` (outright absolute)

## Fix

Resolve `absolute_url` as a **relative reference** via the URL parser and **pin the origin** (`courtListenerSourceUrl`). The string-concat vector disappears because a relative-reference resolve treats `@evil.com/x` as a path segment, and an absolute/protocol-relative URL surfaces its true origin, which is then rejected. Anything not resolving to the CourtListener origin collapses to `''` — an empty, schema-valid sourceUrl that renders no off-site href. Normal relative paths resolve **byte-identically** to the previous output (existing assertion at `annotator.test.ts:87` unchanged and still green).

## Testing

- **+5 tests**: normal path resolves correctly; off-origin absolute, protocol-relative, and `@`-authority trick all collapse to `''` / stay same-origin; unparseable input → `''`.
- `pnpm --filter @civic-source/annotator test` → **90 passed**.
- typecheck / lint / build clean.

## Scope

Finding 1 only. Findings **2** (client reimplements retry — bypasses shared `Retry-After`/abort/timeout hardening) and **3** (no response size cap) remain tracked in #223; #2 is a more involved refactor I left for review. Independent of #220/#222/#224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)