### PR TITLE
fix(fetcher): decouple decompressed-size cap from download cap (#226)

### DIFF
--- a/packages/fetcher/src/__tests__/zip.test.ts
+++ b/packages/fetcher/src/__tests__/zip.test.ts
@@ -73,10 +73,10 @@ describe('extractXmlFromZip', () => {
   });
 
   it('defaults the decompressed cap above the compressed-download cap (#226)', () => {
-    // Regression guard for #226: the inflate cap must NOT be tied to the
-    // compressed-download cap. XML inflates ~10-20x, so the all-titles archive
-    // (~100-150 MB compressed) can decompress past 300 MiB; collapsing these
-    // two bounds back together would false-drop legitimate large titles.
+    // Regression guard for #226: the inflate cap (one decompressed .xml entry)
+    // must NOT be tied to the compressed-download cap. XML inflates ~10-20x, so
+    // a single title's entry can decompress past 300 MiB; collapsing these two
+    // bounds back together would false-drop legitimate large titles.
     expect(MAX_DECOMPRESSED_BYTES).toBeGreaterThan(MAX_DOWNLOAD_BYTES);
   });
 });

--- a/packages/fetcher/src/__tests__/zip.test.ts
+++ b/packages/fetcher/src/__tests__/zip.test.ts
@@ -1,6 +1,7 @@
 import { deflateRawSync } from 'node:zlib';
 import { describe, expect, it } from 'vitest';
 
+import { MAX_DECOMPRESSED_BYTES, MAX_DOWNLOAD_BYTES } from '../constants.js';
 import { extractXmlFromZip } from '../zip.js';
 
 /**
@@ -69,5 +70,13 @@ describe('extractXmlFromZip', () => {
     const xml = '<uscDoc>under the cap</uscDoc>';
     const zip = makeZip('doc.xml', 8, deflateRawSync(Buffer.from(xml, 'utf-8')));
     expect(extractXmlFromZip(zip, 1024)).toBe(xml);
+  });
+
+  it('defaults the decompressed cap above the compressed-download cap (#226)', () => {
+    // Regression guard for #226: the inflate cap must NOT be tied to the
+    // compressed-download cap. XML inflates ~10-20x, so the all-titles archive
+    // (~100-150 MB compressed) can decompress past 300 MiB; collapsing these
+    // two bounds back together would false-drop legitimate large titles.
+    expect(MAX_DECOMPRESSED_BYTES).toBeGreaterThan(MAX_DOWNLOAD_BYTES);
   });
 });

--- a/packages/fetcher/src/constants.ts
+++ b/packages/fetcher/src/constants.ts
@@ -36,14 +36,17 @@ export function allTitlesXmlUrl(congress: string, law: string): string {
 export const MAX_DOWNLOAD_BYTES = 314572800; // 300 MiB
 
 /**
- * Maximum number of bytes to accept from a single *decompressed* ZIP entry.
+ * Maximum number of bytes to accept from a single *decompressed* `.xml` entry.
  *
- * This is deliberately decoupled from {@link MAX_DOWNLOAD_BYTES}, which bounds
- * the *compressed* download. XML inflates roughly 10-20x, so the all-titles
- * archive (~100-150 MB compressed) can decompress well past 300 MiB —
- * reusing the compressed cap as the inflate cap would false-drop legitimate
- * large titles (#226). 1 GiB still bounds a decompression bomb (the inflate is
- * aborted via `maxOutputLength`) while leaving ample headroom for real data.
+ * `extractXmlFromZip` returns the first `.xml` entry of a single-title ZIP, so
+ * this bounds *one title's* inflated XML — not a whole archive. It is decoupled
+ * from {@link MAX_DOWNLOAD_BYTES} (which bounds the *compressed* download)
+ * because XML inflates roughly 10-20x: a title whose compressed entry sits well
+ * under the download cap can still inflate past 300 MiB, and reusing the
+ * compressed cap as the inflate cap would false-drop it (#226). The largest
+ * single USC title decompresses to well under 1 GiB, so this leaves ample
+ * headroom for real data while still aborting a decompression bomb (the inflate
+ * exceeds `maxOutputLength` and throws).
  */
 export const MAX_DECOMPRESSED_BYTES = 1073741824; // 1 GiB
 

--- a/packages/fetcher/src/constants.ts
+++ b/packages/fetcher/src/constants.ts
@@ -35,6 +35,18 @@ export function allTitlesXmlUrl(congress: string, law: string): string {
  */
 export const MAX_DOWNLOAD_BYTES = 314572800; // 300 MiB
 
+/**
+ * Maximum number of bytes to accept from a single *decompressed* ZIP entry.
+ *
+ * This is deliberately decoupled from {@link MAX_DOWNLOAD_BYTES}, which bounds
+ * the *compressed* download. XML inflates roughly 10-20x, so the all-titles
+ * archive (~100-150 MB compressed) can decompress well past 300 MiB —
+ * reusing the compressed cap as the inflate cap would false-drop legitimate
+ * large titles (#226). 1 GiB still bounds a decompression bomb (the inflate is
+ * aborted via `maxOutputLength`) while leaving ample headroom for real data.
+ */
+export const MAX_DECOMPRESSED_BYTES = 1073741824; // 1 GiB
+
 /** Path for hash storage relative to working directory */
 export const HASH_STORE_DIR = '.openlaw-git';
 export const HASH_STORE_FILE = 'hashes.json';

--- a/packages/fetcher/src/zip.ts
+++ b/packages/fetcher/src/zip.ts
@@ -1,6 +1,6 @@
 import { inflateRawSync } from 'node:zlib';
 
-import { MAX_DOWNLOAD_BYTES } from './constants.js';
+import { MAX_DECOMPRESSED_BYTES } from './constants.js';
 
 /**
  * Extract the first `.xml` entry from a ZIP archive buffer.
@@ -14,16 +14,19 @@ import { MAX_DOWNLOAD_BYTES } from './constants.js';
  * The caller is responsible for decoding any base64 before passing the buffer.
  *
  * @param zip Raw ZIP archive bytes.
- * @param maxDecompressedBytes Hard cap on inflated output. The download-side
- *   cap bounds *compressed* bytes, but a small deflate entry can expand far
- *   beyond that (a decompression bomb), so `inflateRawSync` is given a
- *   `maxOutputLength`; exceeding it throws and is treated as "no usable XML".
+ * @param maxDecompressedBytes Hard cap on inflated output, defaulting to
+ *   {@link MAX_DECOMPRESSED_BYTES}. This is intentionally larger than the
+ *   compressed-download cap: a small deflate entry can expand far beyond its
+ *   compressed size — either legitimately (XML inflates ~10-20x) or
+ *   maliciously (a decompression bomb). `inflateRawSync` is given this as
+ *   `maxOutputLength`; exceeding it throws and is treated as "no usable XML",
+ *   so the bound stops bombs without false-dropping large real titles (#226).
  * @returns The XML string, or `null` if the archive contains no `.xml` entry
  *   (or the entry is corrupt or exceeds `maxDecompressedBytes`).
  */
 export function extractXmlFromZip(
   zip: Buffer,
-  maxDecompressedBytes: number = MAX_DOWNLOAD_BYTES
+  maxDecompressedBytes: number = MAX_DECOMPRESSED_BYTES
 ): string | null {
   let offset = 0;
   while (offset < zip.length - 30) {

--- a/packages/fetcher/src/zip.ts
+++ b/packages/fetcher/src/zip.ts
@@ -14,13 +14,13 @@ import { MAX_DECOMPRESSED_BYTES } from './constants.js';
  * The caller is responsible for decoding any base64 before passing the buffer.
  *
  * @param zip Raw ZIP archive bytes.
- * @param maxDecompressedBytes Hard cap on inflated output, defaulting to
- *   {@link MAX_DECOMPRESSED_BYTES}. This is intentionally larger than the
- *   compressed-download cap: a small deflate entry can expand far beyond its
- *   compressed size — either legitimately (XML inflates ~10-20x) or
+ * @param maxDecompressedBytes Hard cap on the inflated output of the single
+ *   `.xml` entry this returns, defaulting to {@link MAX_DECOMPRESSED_BYTES}.
+ *   It is larger than the compressed-download cap because one entry can inflate
+ *   far beyond its compressed size — legitimately (XML inflates ~10-20x) or
  *   maliciously (a decompression bomb). `inflateRawSync` is given this as
  *   `maxOutputLength`; exceeding it throws and is treated as "no usable XML",
- *   so the bound stops bombs without false-dropping large real titles (#226).
+ *   so the bound stops bombs without false-dropping a large real title (#226).
  * @returns The XML string, or `null` if the archive contains no `.xml` entry
  *   (or the entry is corrupt or exceeds `maxDecompressedBytes`).
  */


### PR DESCRIPTION
## Summary

Closes #226.

`extractXmlFromZip` defaulted its inflate cap (`inflateRawSync`'s `maxOutputLength`) to `MAX_DOWNLOAD_BYTES` — the cap on the **compressed** download (300 MiB). XML inflates roughly 10-20×, so the all-titles USC archive (~100-150 MB compressed) can decompress well past 300 MiB and would be **false-dropped** as "no usable XML".

## Change

- Add a distinct `MAX_DECOMPRESSED_BYTES` (1 GiB) constant, documented as deliberately decoupled from the compressed-download bound.
- Default `extractXmlFromZip`'s `maxDecompressedBytes` to it.
- The bound still aborts a decompression bomb (inflate exceeds `maxOutputLength` → throws → `null`), so the security property from #220 is preserved; it just no longer conflates "how much we'll download" with "how much that may legitimately inflate to."

## Tests

`pnpm --filter @civic-source/fetcher test` → 155 passed. Adds a regression guard asserting `MAX_DECOMPRESSED_BYTES > MAX_DOWNLOAD_BYTES` so the two bounds can't silently collapse back together. typecheck + lint clean.