### PR TITLE
fix(annotator): validate CourtListener result elements before use (#237)

### DIFF
--- a/packages/annotator/src/__tests__/client.test.ts
+++ b/packages/annotator/src/__tests__/client.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createLogger } from '@civic-source/shared';
+
+import { CourtListenerClient, isCourtListenerResult } from '../client.js';
+
+const VALID = {
+  caseName: 'Doe v. United States',
+  citation: ['123 U.S. 456'],
+  court: 'scotus',
+  dateFiled: '2024-01-15',
+  snippet: 'The court held that the statute applies broadly.',
+  absolute_url: '/opinion/12345/doe-v-united-states/',
+};
+
+describe('isCourtListenerResult (#237)', () => {
+  it('accepts a fully-formed result', () => {
+    expect(isCourtListenerResult(VALID)).toBe(true);
+  });
+
+  it('rejects non-objects', () => {
+    expect(isCourtListenerResult(null)).toBe(false);
+    expect(isCourtListenerResult('x')).toBe(false);
+    expect(isCourtListenerResult(undefined)).toBe(false);
+  });
+
+  it('rejects results missing or mistyping required fields', () => {
+    const noSnippet: Record<string, unknown> = { ...VALID };
+    delete noSnippet['snippet'];
+    expect(isCourtListenerResult(noSnippet)).toBe(false);
+    expect(isCourtListenerResult({ ...VALID, court: 123 })).toBe(false);
+    expect(isCourtListenerResult({ ...VALID, citation: '123 U.S. 456' })).toBe(false); // not an array
+    expect(isCourtListenerResult({ ...VALID, citation: [123] })).toBe(false); // non-string element
+    expect(isCourtListenerResult({ ...VALID, absolute_url: null })).toBe(false);
+  });
+});
+
+describe('CourtListenerClient.searchByStatute (#237)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubFetchJson(body: unknown): void {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, status: 200, json: async () => body }) as unknown as Response)
+    );
+  }
+
+  it('drops malformed result elements and returns only well-formed ones', async () => {
+    const malformed = { caseName: 'Broken', court: 'scotus' }; // missing snippet/citation/etc.
+    stubFetchJson({ count: 2, results: [VALID, malformed] });
+
+    const client = new CourtListenerClient({ token: 't', logger: createLogger('test', 'error') });
+    const result = await client.searchByStatute('18 U.S.C. 111');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0]?.caseName).toBe('Doe v. United States');
+  });
+
+  it('returns an empty list when the envelope has no results array', async () => {
+    stubFetchJson({ detail: 'unexpected shape' });
+
+    const client = new CourtListenerClient({ token: 't', logger: createLogger('test', 'error') });
+    const result = await client.searchByStatute('18 U.S.C. 111');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual([]);
+  });
+});

--- a/packages/annotator/src/client.ts
+++ b/packages/annotator/src/client.ts
@@ -17,14 +17,31 @@ export interface CourtListenerResult {
   absolute_url: string;
 }
 
-/** CourtListener search API response envelope */
-interface SearchResponse {
-  count: number;
-  results: CourtListenerResult[];
+/**
+ * Validate that an unknown value is a well-formed CourtListener result.
+ *
+ * The search API is untrusted: a result object missing or mistyping a field
+ * (e.g. no `snippet`, a non-array `citation`, a numeric `court`) would later
+ * make `annotateSection` throw on `result.citation[0]` / `mapCourt(...)` /
+ * truncation, escaping its `Result<>` contract as a rejected promise. Checking
+ * every field up front lets the client drop malformed elements instead (#237).
+ */
+export function isCourtListenerResult(value: unknown): value is CourtListenerResult {
+  if (typeof value !== 'object' || value === null) return false;
+  const o = value as Record<string, unknown>;
+  return (
+    typeof o['caseName'] === 'string' &&
+    Array.isArray(o['citation']) &&
+    o['citation'].every((c) => typeof c === 'string') &&
+    typeof o['court'] === 'string' &&
+    typeof o['dateFiled'] === 'string' &&
+    typeof o['snippet'] === 'string' &&
+    typeof o['absolute_url'] === 'string'
+  );
 }
 
-/** Validate that an unknown value has the expected SearchResponse shape */
-function isSearchResponse(data: unknown): data is SearchResponse {
+/** Validate that an unknown value has the expected search-response envelope */
+function hasResultsArray(data: unknown): data is { results: unknown[] } {
   if (typeof data !== 'object' || data === null) return false;
   const obj = data as Record<string, unknown>;
   return Array.isArray(obj['results']);
@@ -79,10 +96,17 @@ export class CourtListenerClient {
     if (!result.ok) return result;
 
     const data = result.value;
-    if (!isSearchResponse(data)) {
+    if (!hasResultsArray(data)) {
       return ok([]);
     }
-    return ok(data.results);
+    // Drop any malformed result element so callers only ever receive
+    // well-formed CourtListenerResult objects (#237).
+    const valid = data.results.filter(isCourtListenerResult);
+    const dropped = data.results.length - valid.length;
+    if (dropped > 0) {
+      this.logger.warn('Dropped malformed CourtListener results', { section, dropped });
+    }
+    return ok(valid);
   }
 
   /** Fetch with exponential backoff retry, including 429 handling */


### PR DESCRIPTION
## Summary

`isSearchResponse` only checked `Array.isArray(results)` — individual elements were cast straight to `CourtListenerResult` without field validation. The CourtListener search API is untrusted, so a result element missing or mistyping a field (no `snippet`, a non-array `citation`, a numeric `court`) made `annotateSection` throw on `result.citation[0]` / `mapCourt(...)` / truncation. Because `annotateSection` returns a `Result<>`, that throw escaped as a **rejected promise** — invisible to a caller checking `result.ok`, and able to abort a whole annotation batch on one bad element.

## Fix

- Add `isCourtListenerResult` that type-checks every field (`caseName`, `citation: string[]`, `court`, `dateFiled`, `snippet`, `absolute_url`).
- `searchByStatute` now **drops malformed elements** (logging the dropped count) and returns only well-formed results, so callers never see a partial object. The envelope-only check is renamed `hasResultsArray`.

Graceful degradation: a malformed element is skipped rather than tanking the section.

## Tests

`client.test.ts` (new): validator unit tests (missing/mistyped fields rejected) + `searchByStatute` filtering malformed elements via a real client with stubbed `fetch`.

Annotator package: lint, typecheck, and 110 tests green locally.

Closes #237