### PR TITLE
fix(fetcher): stream-cap fetchXml body instead of buffering the whole ZIP (#231)

### DIFF
--- a/packages/fetcher/src/__tests__/fetcher.test.ts
+++ b/packages/fetcher/src/__tests__/fetcher.test.ts
@@ -8,6 +8,7 @@ import {
   parsePriorReleasePoints,
   parseCurrentRelease,
   readBodyCapped,
+  readBytesCapped,
 } from '../fetcher.js';
 import { HashStore } from '../hash-store.js';
 import { createLogger } from '@civic-source/shared';
@@ -603,5 +604,50 @@ describe('readBodyCapped', () => {
       },
     });
     expect(await readBodyCapped(new Response(stream), 1000)).toBe('café');
+  });
+});
+
+// --- readBytesCapped (binary streaming size guard used by fetchXml) ---
+
+describe('readBytesCapped (#231)', () => {
+  function streamedResponse(chunks: Uint8Array[], onCancel?: () => void): Response {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const c of chunks) controller.enqueue(c);
+        controller.close();
+      },
+      cancel() {
+        onCancel?.();
+      },
+    });
+    return new Response(stream);
+  }
+
+  it('returns the full buffer when under the cap', async () => {
+    const res = streamedResponse([Uint8Array.from([0x50, 0x4b]), Uint8Array.from([1, 2, 3])]);
+    const buf = await readBytesCapped(res, 1000);
+    expect(buf).not.toBeNull();
+    expect(buf && Array.from(buf)).toEqual([0x50, 0x4b, 1, 2, 3]);
+  });
+
+  it('returns null and cancels the stream once the cap is exceeded (no full buffering)', async () => {
+    // A body with NO Content-Length (chunked) — the case the pre-check cannot
+    // catch and the old arrayBuffer() path would have fully buffered.
+    let cancelled = false;
+    const res = streamedResponse(
+      [new Uint8Array(4), new Uint8Array(4), new Uint8Array(4)], // 12 bytes
+      () => {
+        cancelled = true;
+      }
+    );
+    expect(await readBytesCapped(res, 5)).toBeNull();
+    expect(cancelled).toBe(true);
+  });
+
+  it('falls back to a buffered read when there is no body stream', async () => {
+    const res = new Response(Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+    Object.defineProperty(res, 'body', { value: null });
+    const buf = await readBytesCapped(res, 1000);
+    expect(buf && Array.from(buf)).toEqual([0x50, 0x4b, 0x03, 0x04]);
   });
 });

--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -33,25 +33,25 @@ export function exceedsContentLengthLimit(response: Response): boolean {
 }
 
 /**
- * Read an HTML response body, enforcing a hard byte cap.
+ * Read a response body into a Buffer, enforcing a hard byte cap.
  *
  * `exceedsContentLengthLimit` is the primary defense, but it returns false for
  * a response with no (or untruthful) Content-Length — e.g. a chunked body. To
- * actually bound memory (rather than buffer-then-check), this streams the body
- * and aborts the read as soon as the running total exceeds `maxBytes`, so an
- * oversized or unbounded response is never fully materialized.
+ * actually bound memory (rather than buffer-then-check via arrayBuffer()), this
+ * streams the body and aborts the read as soon as the running total exceeds
+ * `maxBytes`, so an oversized or unbounded response is never fully materialized.
  *
- * @returns The decoded body, or `null` if it exceeds the size cap.
+ * @returns The body bytes, or `null` if it exceeds the size cap.
  */
-export async function readBodyCapped(
+export async function readBytesCapped(
   response: Response,
   maxBytes: number = MAX_DOWNLOAD_BYTES
-): Promise<string | null> {
+): Promise<Buffer | null> {
   const body = response.body;
   if (body === null) {
     // No readable stream (e.g. an empty body); fall back to a buffered read.
     const buffer = Buffer.from(await response.arrayBuffer());
-    return buffer.length > maxBytes ? null : buffer.toString('utf-8');
+    return buffer.length > maxBytes ? null : buffer;
   }
 
   const reader = body.getReader();
@@ -74,9 +74,23 @@ export async function readBodyCapped(
   } finally {
     reader.releaseLock();
   }
-  // Concatenate first, then decode, so multi-byte UTF-8 sequences split across
-  // chunk boundaries are not corrupted.
-  return Buffer.concat(chunks).toString('utf-8');
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Read an HTML response body as a UTF-8 string, enforcing a hard byte cap.
+ *
+ * Thin wrapper over {@link readBytesCapped}: concatenate first, then decode, so
+ * multi-byte UTF-8 sequences split across chunk boundaries are not corrupted.
+ *
+ * @returns The decoded body, or `null` if it exceeds the size cap.
+ */
+export async function readBodyCapped(
+  response: Response,
+  maxBytes: number = MAX_DOWNLOAD_BYTES
+): Promise<string | null> {
+  const bytes = await readBytesCapped(response, maxBytes);
+  return bytes === null ? null : bytes.toString('utf-8');
 }
 
 /**
@@ -374,11 +388,11 @@ export class OlrcFetcher implements IUsCodeFetcher {
       return err(new Error('Download exceeds size limit'));
     }
 
-    const buffer = Buffer.from(await result.value.arrayBuffer());
-
-    // Defense-in-depth: catch oversized bodies that lacked a (truthful)
-    // Content-Length header.
-    if (buffer.length > MAX_DOWNLOAD_BYTES) {
+    // Memory-bounded read: stream the body and abort once the cap is exceeded,
+    // so a chunked or untruthful-Content-Length response (which the pre-check
+    // above cannot catch) is never fully buffered into memory.
+    const buffer = await readBytesCapped(result.value);
+    if (buffer === null) {
       const durationMs = performance.now() - startMs;
       this.metrics.recordDuration(durationMs);
       this.metrics.recordError('network');


### PR DESCRIPTION
## Summary

`fetchXml` read the entire response with `Buffer.from(await result.value.arrayBuffer())` and only checked `buffer.length > MAX_DOWNLOAD_BYTES` **afterward**. The `Content-Length` pre-check is the primary guard, but a chunked / untruthful-`Content-Length` response slips past it — so an oversized or unbounded body was fully materialized into memory before the length check, a runner-OOM vector.

## Fix

- Extract the streaming size-guard already used by `readBodyCapped` into **`readBytesCapped(response, maxBytes): Buffer | null`** — it streams the body and aborts (`reader.cancel()`) the instant the running total exceeds the cap, so an oversized body is never fully buffered.
- `readBodyCapped` becomes a thin UTF-8 decoder over `readBytesCapped`.
- `fetchXml` now reads via `readBytesCapped` and returns the same `'Download exceeds size limit'` error on overflow — memory-bounded for the no-/false-Content-Length case the pre-check can't catch.

## Tests

New `readBytesCapped` tests: returns full buffer under cap; returns `null` and **cancels the stream** once a no-Content-Length body exceeds the cap (proving it doesn't buffer everything); no-body `arrayBuffer` fallback. Existing `fetchXml` tests (valid ZIP, unchanged-hash, Content-Length reject, non-ZIP) still pass.

Full fetcher suite green (162 tests); lint + typecheck clean.

Closes #231