### PR TITLE
fix(scripts): distinguish absent vs failed title fetches; gate resume cursor (#236)

### DIFF
--- a/scripts/import-history.ts
+++ b/scripts/import-history.ts
@@ -115,26 +115,35 @@ async function processBatch(
   rp: ReleasePointId,
   state: ImportState,
   rateLimiter: TokenBucket
-): Promise<{ titlesChanged: number; sectionsChanged: number }> {
+): Promise<{ titlesChanged: number; sectionsChanged: number; failedTitles: number }> {
   let titlesChanged = 0;
   let sectionsChanged = 0;
+  let failedTitles = 0;
 
   const results = await Promise.all(
     batch.map(async (paddedTitle) => {
-      const xml = await downloadAndExtractXml(rp, paddedTitle, rateLimiter, log);
-      if (!xml) return { paddedTitle, files: [] as MarkdownFile[] };
+      const fetched = await downloadAndExtractXml(rp, paddedTitle, rateLimiter, log);
+      // A transient failure (or a present-but-corrupt archive) must be counted
+      // so the caller does not advance the resume cursor past it (#236).
+      if (fetched.kind === 'failed') {
+        return { paddedTitle, files: [] as MarkdownFile[], failed: true };
+      }
+      if (fetched.kind === 'absent') {
+        return { paddedTitle, files: [] as MarkdownFile[], failed: false };
+      }
 
       const transformer = new XmlToMarkdownAdapter(rp.label);
-      const result = transformer.transformToFiles(xml);
+      const result = transformer.transformToFiles(fetched.xml);
       if (!result.ok) {
         log.warn('Transform failed', { title: paddedTitle, error: result.error.message });
-        return { paddedTitle, files: [] as MarkdownFile[] };
+        return { paddedTitle, files: [] as MarkdownFile[], failed: true };
       }
-      return { paddedTitle, files: result.value };
+      return { paddedTitle, files: result.value, failed: false };
     })
   );
 
-  for (const { paddedTitle, files } of results) {
+  for (const { paddedTitle, files, failed } of results) {
+    if (failed) failedTitles++;
     if (files.length === 0) continue;
 
     const currentManifest = buildManifest(files);
@@ -177,7 +186,7 @@ async function processBatch(
     });
   }
 
-  return { titlesChanged, sectionsChanged };
+  return { titlesChanged, sectionsChanged, failedTitles };
 }
 
 async function processReleasePoint(
@@ -186,16 +195,18 @@ async function processReleasePoint(
   rateLimiter: TokenBucket,
   metrics: ImportMetrics,
   totalPoints: number
-): Promise<void> {
+): Promise<{ failedTitles: number }> {
   log.info('Processing release point', { label: rp.label });
   let totalChanged = 0;
   let totalTitlesChanged = 0;
+  let failedTitles = 0;
 
   for (let i = 0; i < titlesToProcess.length; i += MAX_CONCURRENT) {
     const batch = titlesToProcess.slice(i, i + MAX_CONCURRENT);
     const result = await processBatch(batch, rp, state, rateLimiter);
     totalChanged += result.sectionsChanged;
     totalTitlesChanged += result.titlesChanged;
+    failedTitles += result.failedTitles;
 
     if (i + MAX_CONCURRENT < titlesToProcess.length) {
       await new Promise<void>((r) => setTimeout(r, INTER_TITLE_DELAY_MS));
@@ -216,9 +227,24 @@ async function processReleasePoint(
     log.info('No changes for release point', { label: rp.label });
   }
 
-  state.lastCompletedReleasePoint = `${rp.congress}-${rp.law}`;
-  if (!dryRun) {
-    await saveState(repoPath, state);
+  // Only advance the resume cursor when every title at this release point was
+  // accounted for (imported or legitimately absent). If any title hit a
+  // transient failure, leave the cursor where it was so --resume reprocesses
+  // this release point and retries the failed title — saved manifests make the
+  // already-imported titles no-ops, so the retry is cheap and idempotent (#236).
+  if (failedTitles > 0) {
+    log.error('Release point had failed titles; NOT advancing resume cursor', {
+      label: rp.label,
+      failedTitles,
+    });
+    if (!dryRun) {
+      await saveState(repoPath, state); // persist manifests, but not the cursor
+    }
+  } else {
+    state.lastCompletedReleasePoint = `${rp.congress}-${rp.law}`;
+    if (!dryRun) {
+      await saveState(repoPath, state);
+    }
   }
 
   metrics.releasePointsProcessed++;
@@ -245,6 +271,8 @@ async function processReleasePoint(
         : null,
     });
   }
+
+  return { failedTitles };
 }
 
 // --- Main ---
@@ -303,15 +331,21 @@ async function main(): Promise<void> {
     titleFilter: titleFilter ? parseInt(titleFilter, 10) : 'all',
   });
 
+  let releasePointsWithFailures = 0;
   for (const rp of points) {
     try {
-      await processReleasePoint(rp, state, rateLimiter, metrics, points.length);
+      const { failedTitles } = await processReleasePoint(rp, state, rateLimiter, metrics, points.length);
+      if (failedTitles > 0) releasePointsWithFailures++;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      log.error('Release point failed, continuing to next', { label: rp.label, error: msg });
-      // Save state so we don't retry this one
-      state.lastCompletedReleasePoint = `${rp.congress}-${rp.law}`;
-      if (!dryRun) await saveState(repoPath, state);
+      // Do NOT advance the resume cursor here: a thrown release point is an
+      // unrecovered failure, so leaving the cursor lets --resume retry it on a
+      // later run rather than permanently skipping it (#236).
+      log.error('Release point failed, continuing to next (cursor not advanced)', {
+        label: rp.label,
+        error: msg,
+      });
+      releasePointsWithFailures++;
     }
   }
 
@@ -320,9 +354,19 @@ async function main(): Promise<void> {
     releasePointsProcessed: metrics.releasePointsProcessed,
     titlesChanged: metrics.titlesChanged,
     sectionsChanged: metrics.sectionsChanged,
+    releasePointsWithFailures,
     elapsedSeconds: Math.round(elapsed),
     dryRun,
   });
+
+  // Exit non-zero when any release point had unrecovered failures, so CI and
+  // operators notice silent gaps rather than treating the run as fully successful.
+  if (releasePointsWithFailures > 0) {
+    log.error('Import finished with unrecovered failures; rerun with --resume to retry', {
+      releasePointsWithFailures,
+    });
+    process.exit(1);
+  }
 }
 
 main().catch((error: unknown) => {

--- a/scripts/lib/import-helpers.ts
+++ b/scripts/lib/import-helpers.ts
@@ -105,18 +105,38 @@ async function isDocNotFound(response: Response): Promise<boolean> {
   return false;
 }
 
+/**
+ * Outcome of a single title fetch+extract, distinguishing a title that is
+ * legitimately *absent* at a release point from a *transient failure* (#236).
+ * The two were previously collapsed to `null`, so a network blip looked
+ * identical to "not published yet" and the resume cursor advanced past it,
+ * permanently dropping the title's update from the historical record.
+ */
+export type TitleFetch =
+  | { kind: 'ok'; xml: string }
+  | { kind: 'absent' }
+  | { kind: 'failed'; reason: string };
+
+/** Internal outcome of the HTTP fetch, before ZIP extraction. */
+type FetchOutcome =
+  | { kind: 'response'; response: Response }
+  | { kind: 'absent' }
+  | { kind: 'failed'; reason: string };
+
 async function fetchWithRateRetry(
   url: string,
   log: Logger,
   maxRetries = 3
-): Promise<Response | null> {
+): Promise<FetchOutcome> {
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
       const response = await fetch(url, { redirect: 'follow' });
+      // 301/302 and 404 mean the title genuinely is not at this release point
+      // (OLRC redirects unavailable titles); the doc-not-found HTML page too.
       if (response.status === 302 || response.status === 301) {
-        return null;
+        return { kind: 'absent' };
       }
-      if (response.status === 404) return null;
+      if (response.status === 404) return { kind: 'absent' };
       if (response.status === 429) {
         log.warn('Rate limited, waiting 30s', { url, attempt });
         await new Promise<void>((r) => setTimeout(r, RATE_LIMIT_BACKOFF_MS));
@@ -128,12 +148,12 @@ async function fetchWithRateRetry(
           await new Promise<void>((r) => setTimeout(r, 5000 * attempt));
           continue;
         }
-        return null;
+        return { kind: 'failed', reason: `HTTP ${response.status} after ${maxRetries} attempts` };
       }
       if (await isDocNotFound(response)) {
-        return null;
+        return { kind: 'absent' };
       }
-      return response;
+      return { kind: 'response', response };
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'unknown';
       log.warn('Network error, retrying', { url, attempt, error: msg });
@@ -142,10 +162,11 @@ async function fetchWithRateRetry(
         continue;
       }
       log.error('Network error after all retries', { url, attempts: maxRetries });
-      return null;
+      return { kind: 'failed', reason: `network error after ${maxRetries} attempts: ${msg}` };
     }
   }
-  return null;
+  // Loop fell through (e.g. 429 never cleared within maxRetries) — transient.
+  return { kind: 'failed', reason: `rate-limited past ${maxRetries} attempts` };
 }
 
 export async function downloadAndExtractXml(
@@ -153,7 +174,7 @@ export async function downloadAndExtractXml(
   paddedTitle: string,
   rateLimiter: TokenBucket,
   log: Logger
-): Promise<string | null> {
+): Promise<TitleFetch> {
   const url = titleZipUrl(rp, paddedTitle);
   // Random per-invocation temp dir under the OS temp root — no predictable
   // path, no symlink race.
@@ -164,19 +185,29 @@ export async function downloadAndExtractXml(
   await rateLimiter.waitAndConsume();
 
   try {
-    const response = await fetchWithRateRetry(url, log);
-    if (!response) {
+    const outcome = await fetchWithRateRetry(url, log);
+    if (outcome.kind === 'absent') {
       log.info('Title not available at release point', {
         title: parseInt(paddedTitle, 10),
         releasePoint: `PL ${rp.congress}-${rp.law}`,
       });
-      return null;
+      return { kind: 'absent' };
+    }
+    if (outcome.kind === 'failed') {
+      log.warn('Title fetch failed (transient)', {
+        title: parseInt(paddedTitle, 10),
+        releasePoint: `PL ${rp.congress}-${rp.law}`,
+        reason: outcome.reason,
+      });
+      return { kind: 'failed', reason: outcome.reason };
     }
 
-    const buf = Buffer.from(await response.arrayBuffer());
+    const buf = Buffer.from(await outcome.response.arrayBuffer());
+    // A present-but-corrupt archive is a failure (worth retrying / surfacing),
+    // not a legitimate absence.
     if (buf.length < 4 || buf[0] !== 0x50 || buf[1] !== 0x4b) {
       log.warn('Invalid ZIP', { url });
-      return null;
+      return { kind: 'failed', reason: 'invalid ZIP (no PK signature)' };
     }
 
     await writeFile(tmpZip, buf);
@@ -184,10 +215,13 @@ export async function downloadAndExtractXml(
     await execFileAsync('unzip', ['-o', '-q', tmpZip, '-d', tmpDir], { timeout: 60_000 });
 
     const xmlPath = findXmlFile(tmpDir);
-    if (!xmlPath) return null;
+    if (!xmlPath) return { kind: 'failed', reason: 'no XML entry in archive' };
 
-    return await readFile(xmlPath, 'utf-8');
+    return { kind: 'ok', xml: await readFile(xmlPath, 'utf-8') };
   } finally {
     await rm(workDir, { recursive: true, force: true }).catch(() => {});
   }
 }
+
+// Exported for unit testing the absent-vs-failed classification.
+export { fetchWithRateRetry as _fetchWithRateRetry };


### PR DESCRIPTION
## Summary

`fetchWithRateRetry` returned the same `null` for a title that is **legitimately absent** at a release point (301/302/404/doc-not-found) and for a **transient failure** (5xx after retries, 429 exhaustion, network error after retries). `downloadAndExtractXml` logged both as the misleading info line `"Title not available"`, `processBatch` skipped them identically, and `processReleasePoint` advanced `lastCompletedReleasePoint` **unconditionally** — so a network blip during a multi-hour import permanently dropped a title's update from the historical git record, and `--resume` never retried it. The main loop *also* advanced the cursor on a thrown release point.

## Fix

- **Discriminate outcomes:** `TitleFetch = { ok } | { absent } | { failed }`. `fetchWithRateRetry` returns a `FetchOutcome`; `downloadAndExtractXml` returns `TitleFetch`. A present-but-corrupt archive or missing XML entry is `failed` (worth retrying/surfacing), not `absent`.
- **Gate the cursor:** `processBatch` counts `failedTitles`; `processReleasePoint` advances `lastCompletedReleasePoint` only when `failedTitles === 0`. On failure it still saves manifests, so `--resume` reprocesses the release point and re-imports **only** the failed title (already-imported titles are no-op deltas — cheap and idempotent).
- **Surface it:** the main loop no longer advances the cursor on a thrown release point, and exits **non-zero** when any release point had unrecovered failures, so silent gaps no longer look like a clean run.

## Verification

Classification verified via `tsx` (404/302/doc-not-found → `absent`; 200 ZIP → `response`; persistent 5xx / network error → `failed`).

> Note: `scripts/` is not a pnpm workspace package and imports `@civic-source/shared`/`types` which aren't symlinked at the repo root, so it has no CI test/typecheck (the pre-existing `delta-detector.test.ts` is similarly local-only). Wiring `scripts/` into CI is a worthwhile separate follow-up; kept out of scope here. CI green reflects that workspace packages are unaffected.

Closes #236