### PR TITLE
fix(fetcher): guard HashStore.load against non-object stores (#238)

### DIFF
--- a/packages/fetcher/src/__tests__/hash-store.test.ts
+++ b/packages/fetcher/src/__tests__/hash-store.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { HashStore } from '../hash-store.js';
+import { HASH_STORE_DIR, HASH_STORE_FILE } from '../constants.js';
+
+describe('HashStore.load shape guard (#238)', () => {
+  let base: string;
+
+  beforeEach(async () => {
+    base = await mkdtemp(join(tmpdir(), 'hashstore-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(base, { recursive: true, force: true });
+  });
+
+  /** Write a raw hashes.json (bypassing HashStore.save) to simulate a corrupt store. */
+  async function writeRawStore(contents: string): Promise<void> {
+    const dir = join(base, HASH_STORE_DIR);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, HASH_STORE_FILE), contents, 'utf-8');
+  }
+
+  it('round-trips a valid store', async () => {
+    const store = new HashStore(base);
+    await store.setHash('k', 'abc');
+    expect(await store.getHash('k')).toBe('abc');
+    expect(await store.hasChanged('k', 'abc')).toBe(false);
+    expect(await store.hasChanged('k', 'def')).toBe(true);
+  });
+
+  it('degrades to empty on invalid JSON (does not throw)', async () => {
+    await writeRawStore('{ not valid json');
+    const store = new HashStore(base);
+    expect(await store.getHash('k')).toBeUndefined();
+    await store.setHash('k', 'abc'); // must not throw
+    expect(await store.getHash('k')).toBe('abc');
+  });
+
+  it('treats a null payload as empty instead of throwing on null[key]', async () => {
+    await writeRawStore('null');
+    const store = new HashStore(base);
+    expect(await store.getHash('k')).toBeUndefined();
+    await store.setHash('k', 'abc'); // previously threw: null[key] = ...
+    expect(await store.getHash('k')).toBe('abc');
+  });
+
+  it('treats an array payload as empty so setHash is not silently lost', async () => {
+    await writeRawStore('[]');
+    const store = new HashStore(base);
+    await store.setHash('k', 'abc');
+    // With an array store, JSON.stringify would have dropped the property.
+    const reopened = new HashStore(base);
+    expect(await reopened.getHash('k')).toBe('abc');
+  });
+
+  it('treats a primitive payload as empty', async () => {
+    await writeRawStore('42');
+    const store = new HashStore(base);
+    expect(await store.getHash('k')).toBeUndefined();
+    await store.setHash('k', 'abc');
+    expect(await store.getHash('k')).toBe('abc');
+  });
+});

--- a/packages/fetcher/src/hash-store.ts
+++ b/packages/fetcher/src/hash-store.ts
@@ -39,7 +39,15 @@ export class HashStore {
   private async load(): Promise<HashRecord> {
     try {
       const raw = await readFile(this.filePath, 'utf-8');
-      return JSON.parse(raw) as HashRecord;
+      const parsed: unknown = JSON.parse(raw);
+      // Guard the shape: a corrupt store that parses to null, an array, or a
+      // primitive would otherwise make getHash/setHash throw (null[key]) or
+      // silently drop writes (array property lost by JSON.stringify). Treat any
+      // non-plain-object as an empty store (#238).
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        return {};
+      }
+      return parsed as HashRecord;
     } catch {
       return {};
     }


### PR DESCRIPTION
## Summary

`HashStore.load()` did `JSON.parse(raw) as HashRecord` with no shape validation. A corrupt idempotency store silently breaks change detection:
- a `null` payload → `getHash`/`setHash` throw on `null[key]`
- an array `[]` payload → `setHash` sets a property that `JSON.stringify([])` **drops**, silently losing the write
- a primitive (`42`) → property assignment throws (strict mode)

Any of these either crashes the fetcher or makes it re-commit/skip content incorrectly.

## Fix

After parsing, verify the value is a **non-null plain object** (not `null`, not an array); otherwise treat it as an empty store — the same safe degrade as the existing invalid-JSON path. (Distinct from the `setHash` write-rejection tracked under #233; this is the read/parse path.)

## Tests

`hash-store.test.ts` (new): valid round-trip; degrades to empty (no throw, writes recover) for invalid JSON, `null`, `[]`, and a primitive payload.

Fetcher package: lint, typecheck, 166 tests green.

Closes #238