### PR TITLE
ci: enforce PR-title lint, drop Lighthouse no-op, add npm Dependabot (#234)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,15 @@ updates:
     groups:
       actions:
         patterns: ["*"]
+
+  # npm dependencies across the pnpm workspace. Grouped to keep PR volume low;
+  # a modest open-PR limit avoids a flood. Dependabot reads pnpm-lock.yaml and
+  # honours pnpm.overrides, so pinned transitive versions are respected (#234).
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,13 @@ jobs:
 
       - run: pnpm test
 
-      - name: Validate commit messages
+      # The repo squash-merges, so the PR title becomes the commit subject that
+      # release-please parses. Lint that title (not the individual WIP commits)
+      # and enforce it — a malformed title now fails CI rather than silently
+      # warning (#234). The title is untrusted input, so it is passed via env and
+      # never interpolated into the shell (#229 class).
+      - name: Validate PR title (squash-merge subject)
         if: github.event_name == 'pull_request'
-        continue-on-error: true
-        run: |
-          git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }} 2>/dev/null || true
-          npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }}
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$PR_TITLE" | npx commitlint

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -86,16 +86,14 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # Informational audit only — the report is uploaded to temporary public
+      # storage (link in the action logs). No budget is enforced: an empty
+      # `budgetPath` was a no-op, and a real budget would be a flaky,
+      # baseline-less gate, so neither is configured (#234).
       - name: Lighthouse audit
         uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12.6.2
         with:
           urls: |
             https://civic-source.github.io/us-code-tracker/
             https://civic-source.github.io/us-code-tracker/browse/title-18/
-          budgetPath: ''
           temporaryPublicStorage: true
-      - name: Report scores
-        if: always()
-        run: |
-          echo "## Lighthouse Scores" >> "$GITHUB_STEP_SUMMARY"
-          echo "Audit completed after deploy. Check artifacts for full report." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Closes #234.

Tightens three advisory/no-op CI gates flagged in #234.

## Changes
- **`ci.yml`** — replace the per-commit `Validate commit messages` step (which ran `continue-on-error` and only warned) with an **enforced** `Validate PR title` step. The repo squash-merges, so the PR title is the commit subject that release-please parses; that's the string worth linting. The untrusted title is passed via `env:` and piped to `npx commitlint` (never interpolated into the shell — same hardening class as #229).
- **`deploy-site.yml`** — drop the empty `budgetPath: ''` no-op and the placeholder "Report scores" step from the Lighthouse job. The audit stays informational (report uploaded to temporary public storage; link in the action logs).
- **`dependabot.yml`** — add an `npm` ecosystem (weekly, grouped minor/patch, `open-pull-requests-limit: 5`) so workspace deps get update PRs, not just GitHub Actions. Dependabot reads `pnpm-lock.yaml` and honours `pnpm.overrides`.

## Verification
- All three YAML files parse (`yaml.safe_load`).
- No untrusted `${{ github.event.* }}` interpolated into a `run:` body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)