### PR TITLE
chore: remove vestigial exports, types, and constants (#233)

### DIFF
--- a/packages/fetcher/src/constants.ts
+++ b/packages/fetcher/src/constants.ts
@@ -18,14 +18,6 @@ export function titleXmlUrl(congress: string, law: string, title: string): strin
 }
 
 /**
- * Build a URL for the all-titles XML ZIP download for a release point.
- * Pattern: https://uscode.house.gov/download/releasepoints/us/pl/{congress}/{law}/xml_uscAll@{congress}-{law}.zip
- */
-export function allTitlesXmlUrl(congress: string, law: string): string {
-  return `${OLRC_RELEASE_POINTS_URL}us/pl/${congress}/${law}/xml_uscAll@${congress}-${law}.zip`;
-}
-
-/**
  * Maximum number of bytes to accept from a single download.
  *
  * Guards CI runners against OOM from a maliciously or accidentally huge

--- a/packages/fetcher/src/index.ts
+++ b/packages/fetcher/src/index.ts
@@ -4,7 +4,6 @@ export {
   OLRC_PRIOR_RELEASE_POINTS_PAGE,
   OLRC_RELEASE_POINTS_URL,
   titleXmlUrl,
-  allTitlesXmlUrl,
   HASH_STORE_DIR,
   HASH_STORE_FILE,
 } from './constants.js';

--- a/packages/transformer/src/__tests__/transformer.test.ts
+++ b/packages/transformer/src/__tests__/transformer.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
   parseUslmXml,
-  extractText,
   generateFrontmatter,
   buildSectionPath,
   formatListItem,
@@ -141,32 +140,6 @@ describe('parseUslmXml', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.titleNumber).toBe('1');
-  });
-});
-
-describe('extractText', () => {
-  it('returns string values directly', () => {
-    expect(extractText('hello')).toBe('hello');
-  });
-
-  it('extracts #text from objects', () => {
-    expect(extractText({ '#text': 'nested' })).toBe('nested');
-  });
-
-  it('returns empty string for null/undefined/unrecognized', () => {
-    expect(extractText(null)).toBe('');
-    expect(extractText(undefined)).toBe('');
-    expect(extractText({ foo: 'bar' })).toBe('');
-  });
-
-  it('handles numeric values', () => {
-    expect(extractText(42)).toBe('42');
-    expect(extractText({ '#text': 101 })).toBe('101');
-  });
-
-  it('handles preserveOrder arrays', () => {
-    const nodes = [{ '#text': 'hello' }, { '#text': 'world' }];
-    expect(extractText(nodes)).toBe('hello world');
   });
 });
 

--- a/packages/transformer/src/constants.ts
+++ b/packages/transformer/src/constants.ts
@@ -1,13 +1,5 @@
 /** USLM XML element names and transformer configuration */
 
-/**
- * USLM namespace URI.
- * Note: OLRC publishes USLM 1.0 (http://xml.house.gov/schemas/uslm/1.0)
- * which uses `<uscDoc>` as root, while the USLM 2.0 spec uses `<lawDoc>`.
- * The namespace URI is the same; only the schema version and root element differ.
- */
-export const USLM_NAMESPACE = 'https://xml.house.gov/schemas/uslm/1.0';
-
 /** Structural USLM element names (hierarchy order) */
 export const USLM_ELEMENTS = {
   /** Top-level document wrapper (USLM 2.0) */
@@ -58,24 +50,8 @@ export const USLM_ELEMENTS = {
   table: 'table',
 } as const;
 
-/**
- * Legal list markers by nesting depth.
- * (a) → (1) → (A) → (i) → (I) → (aa)
- */
-export const LEGAL_LIST_MARKERS = [
-  { prefix: '(', style: 'lower-alpha' },  // (a), (b), (c)
-  { prefix: '(', style: 'decimal' },       // (1), (2), (3)
-  { prefix: '(', style: 'upper-alpha' },   // (A), (B), (C)
-  { prefix: '(', style: 'lower-roman' },   // (i), (ii), (iii)
-  { prefix: '(', style: 'upper-roman' },   // (I), (II), (III)
-  { prefix: '(', style: 'double-lower' },  // (aa), (bb), (cc)
-] as const;
-
 /** Indentation per nesting level (in spaces) */
 export const INDENT_PER_LEVEL = 2;
 
 /** Maximum nesting depth for safety (prevent runaway recursion) */
 export const MAX_NESTING_DEPTH = 20;
-
-/** Output directory structure pattern */
-export const OUTPUT_PATH_PATTERN = 'statutes/title-{title}/chapter-{chapter}/section-{section}.md';

--- a/packages/transformer/src/index.ts
+++ b/packages/transformer/src/index.ts
@@ -1,5 +1,5 @@
 export { XmlToMarkdownAdapter } from './transformer.js';
-export { parseUslmXml, extractText } from './parser.js';
+export { parseUslmXml } from './parser.js';
 export type { ParsedDocument } from './parser.js';
 export {
   generateFrontmatter,
@@ -14,6 +14,6 @@ export {
   detectSectionStatus,
 } from './markdown-generator.js';
 export type { Frontmatter, MarkdownFile, SectionStatus } from './markdown-generator.js';
-export { USLM_ELEMENTS, USLM_NAMESPACE, INDENT_PER_LEVEL, MAX_NESTING_DEPTH } from './constants.js';
+export { USLM_ELEMENTS, INDENT_PER_LEVEL, MAX_NESTING_DEPTH } from './constants.js';
 export { createLogger } from '@civic-source/shared';
 export { extractTextFromNodes, findElements, getAttributes, getElementName } from './xml-utils.js';

--- a/packages/transformer/src/parser.ts
+++ b/packages/transformer/src/parser.ts
@@ -34,26 +34,6 @@ function createUslmParser(): XMLParser {
   return parser;
 }
 
-/**
- * Extract text from a preserveOrder node array or a plain value.
- * For backward compatibility with markdown-generator and transformer.
- */
-export function extractText(node: unknown): string {
-  if (typeof node === 'string') return node;
-  if (typeof node === 'number') return String(node);
-  if (Array.isArray(node)) return extractTextFromNodes(node);
-  if (node !== null && typeof node === 'object') {
-    const obj = node as Record<string, unknown>;
-    if ('#text' in obj && typeof obj['#text'] === 'string') return obj['#text'];
-    if ('#text' in obj && typeof obj['#text'] === 'number') return String(obj['#text']);
-  }
-  return '';
-}
-
-/**
- * Find the title number from a parsed USLM document (preserveOrder format).
- * Looks for the identifier attribute on the title element.
- */
 /** Find the document root element — either lawDoc (USLM 2.0) or uscDoc (USLM 1.0) */
 function findDocRoot(root: unknown[]): { children: unknown[]; attrs: Record<string, string> } | undefined {
   return findElements(root, USLM_ELEMENTS.lawDoc)[0]

--- a/packages/transformer/src/xml-utils.ts
+++ b/packages/transformer/src/xml-utils.ts
@@ -6,19 +6,6 @@
  * Attributes live in a ":@" sibling key on the same object.
  */
 
-/** A text node in preserveOrder output */
-export interface PreserveOrderTextNode {
-  '#text': string;
-}
-
-/** An element node in preserveOrder output */
-export interface PreserveOrderElementNode {
-  [tag: string]: unknown[];
-}
-
-/** A single node in the preserveOrder output */
-export type PreserveOrderNode = PreserveOrderTextNode | PreserveOrderElementNode;
-
 /**
  * Recursively walk nodes and concatenate all #text values in document order.
  * Joins segments with a single space and collapses whitespace.

--- a/scripts/lib/delta-detector.ts
+++ b/scripts/lib/delta-detector.ts
@@ -5,12 +5,6 @@ export function hashContent(content: string): string {
   return createHash('sha256').update(content, 'utf-8').digest('hex');
 }
 
-/** A file with its path and content hash */
-export interface HashedFile {
-  path: string;
-  hash: string;
-}
-
 /** Result of comparing two sets of files */
 export interface DeltaResult {
   /** Files that are new or have changed content */


### PR DESCRIPTION
Closes #233.

Dead-code sweep. A read-only reconnaissance pass grepped every `export`ed symbol across `packages/*/src`, `scripts/`, `apps/web`, tests, and `.github/` workflows (excluding `dist/`). Each symbol removed below had **zero references** beyond its own definition (and barrel re-export).

## Removed
| Package | Symbol | Why dead |
|---|---|---|
| transformer | `USLM_NAMESPACE`, `LEGAL_LIST_MARKERS`, `OUTPUT_PATH_PATTERN` | constants with no consumers; the path pattern duplicated `buildSectionPath`'s own template |
| transformer | `PreserveOrderTextNode` / `PreserveOrderElementNode` / `PreserveOrderNode` types | not in the barrel, no importers; `mixed-content.test.ts` defines its own local `PreserveOrderNode` |
| transformer | `extractText` (+ its tests) | a "for backward compatibility" shim with no remaining callers — production uses `extractTextFromNodes` |
| fetcher | `allTitlesXmlUrl` | the all-titles archive is never fetched; only per-title `titleXmlUrl` downloads are used |
| scripts | `HashedFile` interface | `buildManifest` uses an inline `{ path, content }` literal instead |

Barrels (`transformer/src/index.ts`, `fetcher/src/index.ts`) updated to drop the removed re-exports.

## Deliberately left alone
- The `getAttributes` / `getAttrsFromNode` transformer duplication (intentional, out of scope per the issue).
- Public-ish `@civic-source/types` exports (`PrecedentImpact`, `ReleasePointSchema`) — low-confidence, kept.

## Verification
Local `pnpm build && pnpm typecheck && pnpm lint && pnpm test` — all green (build 6/6, typecheck 8/8, lint 6/6, test 8/8). Removing the symbols breaks nothing because nothing referenced them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)